### PR TITLE
examples: add a tokio-based timer example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,5 @@ console = ">=0.3.0, <1.0.0"
 
 [dev-dependencies]
 rand = "0"
+futures = "0.1"
+tokio-core = "0.1"

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -1,0 +1,30 @@
+extern crate futures;
+extern crate indicatif;
+extern crate tokio_core;
+
+use futures::Stream;
+use indicatif::ProgressBar;
+use std::time::Duration;
+use tokio_core::reactor::{Core, Interval};
+
+fn main() {
+    // Plain progress bar, totaling 1024 steps.
+    let steps = 1024;
+    let pb = ProgressBar::new(steps);
+
+    // Stream of events, triggering every 5ms.
+    let mut tcore = Core::new().expect("failed to create core");
+    let intv = Interval::new(Duration::from_millis(5), &tcore.handle()).expect("failed to create interval");
+
+    // Future computation which runs for 100 interval events,
+    // incrementing one step of the progress bar each time.
+    let future = intv
+                     .take(steps)
+                     .for_each(|_| Ok(pb.inc(1)));
+
+    // Drive the future to completion, blocking until done.
+    tcore.run(future).expect("failed to complete future");
+
+    // Mark the progress bar as finished.
+    pb.finish();
+}


### PR DESCRIPTION
This adds a simple "timer with progress bar" example showing how to use indicatif together with tokio/futures.
