### PR TITLE
progress: use saturating sub to avoid underflows

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -216,8 +216,9 @@ impl ProgressStyle {
         } else {
             "".into()
         };
+        let bg = width.saturating_sub(fill).saturating_sub(head);
         let rest = repeat(state.style.progress_chars[2])
-            .take(width - fill - head).collect::<String>();
+            .take(bg).collect::<String>();
         format!("{}{}{}", bar, cur, alt_style.unwrap_or(&Style::new()).apply_to(rest))
     }
 
@@ -559,6 +560,14 @@ fn test_pbar_zero() {
 fn test_pbar_maxu64() {
     let pb = ProgressBar::new(!0);
     assert_eq!(pb.state.read().percent(), 0.0);
+}
+
+#[test]
+fn test_pbar_overflow() {
+    let pb = ProgressBar::new(1);
+    pb.set_draw_target(ProgressDrawTarget::hidden());
+    pb.inc(2);
+    pb.finish();
 }
 
 struct MultiObject {

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -322,11 +322,12 @@ impl ProgressState {
 
     /// Returns the completion in percent
     pub fn percent(&self) -> f32 {
-        if self.len == !0 {
-            0.0
-        } else {
-            self.pos as f32 / self.len as f32
-        }
+        let pct = match (self.pos, self.len) {
+            (_, 0) => 100.0,
+            (0, _) => 0.0,
+            (pos, len) => pos as f32 / len as f32,
+        };
+        pct.max(0.0).min(100.0)
     }
 
     /// Returns the position of the status bar as `(pos, len)` tuple.
@@ -548,6 +549,17 @@ impl ProgressBar {
     }
 }
 
+#[test]
+fn test_pbar_zero() {
+    let pb = ProgressBar::new(0);
+    assert_eq!(pb.state.read().percent(), 100.0);
+}
+
+#[test]
+fn test_pbar_maxu64() {
+    let pb = ProgressBar::new(!0);
+    assert_eq!(pb.state.read().percent(), 0.0);
+}
 
 struct MultiObject {
     done: bool,


### PR DESCRIPTION
Note: this is based on top of https://github.com/mitsuhiko/indicatif/pull/14, please consider landing that first.

Fixes https://github.com/mitsuhiko/indicatif/issues/13