### PR TITLE
Allow multiple in-progress characters for bars.

### DIFF
--- a/examples/finebars.rs
+++ b/examples/finebars.rs
@@ -1,0 +1,38 @@
+extern crate indicatif;
+extern crate rand;
+
+use std::thread;
+use std::time::Duration;
+
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use rand::{thread_rng, Rng};
+
+fn main() {
+    let styles = [
+        ("Fine bar:", "█▉▊▋▌▍▎▏  ","red"),
+        ("Vertical:", "█▇▆▅▄▃▂▁  ", "blue"),
+        ("Fade in: ", "█▓▒░  ",      "yellow"),
+        ("Blocky:  ", "█▛▌▖  ",       "green"),
+    ];
+
+    let m = MultiProgress::new();
+
+    for s in styles.iter() {
+        let pb = m.add(ProgressBar::new(512));
+        pb.set_style(ProgressStyle::default_bar()
+            .template(&format!("{{prefix:.bold}}▕{{bar:.{}}}▏{{msg}}", s.2))
+            .progress_chars(s.1));
+        pb.set_prefix(s.0);
+        let wait = Duration::from_millis(thread_rng().gen_range(10, 30));
+        thread::spawn(move || {
+            for i in 0..512 {
+                pb.inc(1);
+                pb.set_message(&format!("{:3}%", 100 * i /512));
+                thread::sleep(wait);
+            }
+            pb.finish_with_message("100%");
+        });
+    }
+
+    m.join().unwrap();
+}

--- a/examples/finebars.rs
+++ b/examples/finebars.rs
@@ -9,10 +9,11 @@ use rand::{thread_rng, Rng};
 
 fn main() {
     let styles = [
-        ("Fine bar:", "█▉▊▋▌▍▎▏  ","red"),
-        ("Vertical:", "█▇▆▅▄▃▂▁  ", "blue"),
-        ("Fade in: ", "█▓▒░  ",      "yellow"),
-        ("Blocky:  ", "█▛▌▖  ",       "green"),
+        ("Rough bar:", "█  ", "red"),
+        ("Fine bar: ", "█▉▊▋▌▍▎▏  ","yellow"),
+        ("Vertical: ", "█▇▆▅▄▃▂▁  ", "green"),
+        ("Fade in:  ", "█▓▒░  ",      "blue"),
+        ("Blocky:   ", "█▛▌▖  ",       "magenta"),
     ];
 
     let m = MultiProgress::new();

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -236,22 +236,20 @@ impl ProgressStyle {
     fn format_bar(&self, state: &ProgressState, width: usize,
                   alt_style: Option<&Style>) -> String {
         let pct = state.percent();
-        let mut fill = (pct * width as f32) as usize;
-        let mut head = 0;
-        if fill > 0 && !state.is_finished() {
-            fill -= 1;
-            head = 1;
-        }
+        let fill = pct * width as f32;
+        let head = if pct > 0.0 && !state.is_finished() { 1 } else { 0 };
 
         let bar = repeat(state.style.progress_chars[0])
-            .take(fill).collect::<String>();
+            .take(fill as usize).collect::<String>();
         let cur = if head == 1 {
-            state.style.progress_chars[1].to_string()
+            let n = state.style.progress_chars.len() - 2;
+            let cur_char = n - ((fill * n as f32) as usize % n);
+            state.style.progress_chars[cur_char].to_string()
         } else {
             "".into()
         };
-        let bg = width.saturating_sub(fill).saturating_sub(head);
-        let rest = repeat(state.style.progress_chars[2])
+        let bg = width.saturating_sub(fill as usize).saturating_sub(head);
+        let rest = repeat(state.style.progress_chars.last().unwrap())
             .take(bg).collect::<String>();
         format!("{}{}{}", bar, cur, alt_style.unwrap_or(&Style::new()).apply_to(rest))
     }


### PR DESCRIPTION
This PR adds the ability to specify multiple characters for the "in progress" part of a progress bar, which
are then displayed in sequence as that part fills up.
This allows a user to show a more precise progress bar, as there can be multiple distinct steps per terminal column.

To use this feature, pass more than 3 characters to `ProgressStyle::progress_chars()`. The first and last characters are still for the "filled" and "to do" parts of the bar, but if there are multiple characters between those, they're used sequentially for the "current" part of the bar.
`examples/finebars.rs` demonstrates how this works:
[![asciicast](https://asciinema.org/a/OCrX70oy90lE2MakVLnUQyJbt.png)](https://asciinema.org/a/OCrX70oy90lE2MakVLnUQyJbt)