### PR TITLE
Fixed last line of yarnish example

### DIFF
--- a/examples/yarnish.rs
+++ b/examples/yarnish.rs
@@ -77,5 +77,5 @@ pub fn main() {
     }
     m.join_and_clear().unwrap();
 
-    println!("{} Done in {}", HumanDuration(started.elapsed()), SPARKLE);
+    println!("{} Done in {}", SPARKLE, HumanDuration(started.elapsed()));
 }


### PR DESCRIPTION
b447ed8ce76b7e5c573d62d1d4c38298b01025ec accidentally reversed the position of the emoji and the elapsed time.