### PR TITLE
Rename Cargo.toml homepage field to repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.8.0"
 keywords = ["cli", "progress", "pb", "colors", "progressbar"]
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
 license = "MIT"
-homepage = "https://github.com/mitsuhiko/indicatif"
+repository = "https://github.com/mitsuhiko/indicatif"
 documentation = "https://docs.rs/indicatif"
 readme = "README.md"
 


### PR DESCRIPTION
I just noticed that the project's Cargo.toml only points to the repository via the "homepage" link, which is not supposed to direct to the repository anyway. This PR should ensure conformance and make the crate a bit more friendly.
  