### PR TITLE
Exclude screenshots from the crate package.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 repository = "https://github.com/mitsuhiko/indicatif"
 documentation = "https://docs.rs/indicatif"
 readme = "README.md"
+exclude = ["screenshots/*"]
 
 [dependencies]
 parking_lot = "0"


### PR DESCRIPTION
This decreases `*.crate` file (the one that cargo uses to build this crate)  size from 1.3MiB to 15.3KiB.