### PR TITLE
Allow logging above the progress bar

### DIFF
--- a/examples/log.rs
+++ b/examples/log.rs
@@ -1,0 +1,16 @@
+extern crate indicatif;
+
+use std::thread;
+use std::time::Duration;
+
+use indicatif::ProgressBar;
+
+fn main() {
+    let pb = ProgressBar::new(100);
+    for i in 0..100 {
+        thread::sleep(Duration::from_millis(250));
+        pb.println(format!("[+] finished #{}", i));
+        pb.inc(1);
+    }
+    pb.finish_with_message("done");
+}


### PR DESCRIPTION
This allows logging some information without interfering with the progress bar.

```rust
extern crate indicatif;

use std::thread;
use std::time::Duration;

use indicatif::ProgressBar;

fn main() {
    let pb = ProgressBar::new(100);
    for i in 0..100 {
        thread::sleep(Duration::from_millis(250));
        pb.println(format!("[+] finished #{}", i));
        pb.inc(1);
    }
    pb.finish_with_message("done");
}
```

Resolves #27 