### PR TITLE
Add decimal and binary bytes keys in style templates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 parking_lot = "0"
 regex = "0.2"
 lazy_static = "0.2"
+number_prefix = "0.2"
 console = ">=0.6.1, <1.0.0"
 
 [dev-dependencies]

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::time::Duration;
 
+use number_prefix::{binary_prefix, decimal_prefix, PrefixNames, Prefixed, Standalone};
 
 /// Wraps an std duration for human basic formatting.
 pub struct FormattedDuration(pub Duration);
@@ -10,6 +11,12 @@ pub struct HumanDuration(pub Duration);
 
 /// Formats bytes for human readability
 pub struct HumanBytes(pub u64);
+
+/// Formats bytes for human readability using SI prefixes
+pub struct DecimalBytes(pub u64);
+
+/// Formats bytes for human readability using ISO/IEC prefixes
+pub struct BinaryBytes(pub u64);
 
 impl fmt::Display for FormattedDuration {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -64,14 +71,27 @@ impl fmt::Display for HumanDuration {
 
 impl fmt::Display for HumanBytes {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let n = self.0 as f64;
-        let kb = 1024f64;
-        match n {
-            n if n >= kb.powf(4_f64) => write!(f, "{:.*}TB", 2, n / kb.powf(4_f64)),
-            n if n >= kb.powf(3_f64) => write!(f, "{:.*}GB", 2, n / kb.powf(3_f64)),
-            n if n >= kb.powf(2_f64) => write!(f, "{:.*}MB", 2, n / kb.powf(2_f64)),
-            n if n >= kb => write!(f, "{:.*}KB", 2, n / kb),
-            _ => write!(f, "{:.*}B", 0, n)
+        match binary_prefix(self.0 as f64) {
+            Standalone(number) => write!(f, "{:.0}B", number),
+            Prefixed(prefix, number) => write!(f, "{:.2}{}B", number, prefix.upper().chars().next().unwrap()),
+        }
+    }
+}
+
+impl fmt::Display for DecimalBytes {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match decimal_prefix(self.0 as f64) {
+            Standalone(number) => write!(f, "{:.0}B", number),
+            Prefixed(prefix, number) => write!(f, "{:.2}{}B", number, prefix),
+        }
+    }
+}
+
+impl fmt::Display for BinaryBytes {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match binary_prefix(self.0 as f64) {
+            Standalone(number) => write!(f, "{:.0}B", number),
+            Prefixed(prefix, number) => write!(f, "{:.2}{}B", number, prefix),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,8 @@
 //!   * [`MultiProgress`](struct.MultiProgress.html) for multiple bars
 //! * **Data Formatting**
 //!   * [`HumanBytes`](struct.HumanBytes.html) for formatting bytes
+//!   * [`DecimalBytes`](struct.DecimalBytes.html) for formatting bytes using SI prefixes
+//!   * [`BinaryBytes`](struct.BinaryBytes.html) for formatting bytes using ISO/IEC prefixes
 //!   * [`HumanDuration`](struct.HumanDuration.html) for formatting durations
 //!
 //! # Progress Bars and Spinners
@@ -137,6 +139,7 @@
 extern crate parking_lot;
 extern crate regex;
 #[macro_use] extern crate lazy_static;
+extern crate number_prefix;
 extern crate console;
 
 mod progress;
@@ -145,4 +148,4 @@ mod format;
 
 pub use progress::{ProgressBar, MultiProgress, ProgressBarIter,
                    ProgressDrawTarget, ProgressStyle};
-pub use format::{HumanDuration, FormattedDuration, HumanBytes};
+pub use format::{HumanDuration, FormattedDuration, HumanBytes, DecimalBytes, BinaryBytes};

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -12,7 +12,7 @@ use parking_lot::{Mutex, RwLock};
 
 use console::{Term, Style, measure_text_width};
 use utils::{expand_template, Estimate, duration_to_secs, secs_to_duration, pad_str};
-use format::{FormattedDuration, HumanDuration, HumanBytes};
+use format::{FormattedDuration, HumanDuration, HumanBytes, DecimalBytes, BinaryBytes};
 
 /// Controls the rendering style of progress bars.
 #[derive(Clone)]
@@ -292,6 +292,14 @@ impl ProgressStyle {
                     format!("{}", HumanBytes(state.pos))
                 } else if key == "total_bytes" {
                     format!("{}", HumanBytes(state.len))
+                } else if key == "decimal_bytes" {
+                    format!("{}", DecimalBytes(state.pos))
+                } else if key == "decimal_total_bytes" {
+                    format!("{}", DecimalBytes(state.len))
+                } else if key == "binary_bytes" {
+                    format!("{}", BinaryBytes(state.pos))
+                } else if key == "binary_total_bytes" {
+                    format!("{}", BinaryBytes(state.len))
                 } else if key == "elapsed_precise" {
                     format!("{}", FormattedDuration(state.started.elapsed()))
                 } else if key == "elapsed" {


### PR DESCRIPTION
 - decimal_{bytes,total_bytes} use SI prefixes
 - binary_{bytes,total_bytes} use ISO/IEC 60027-2 prefixes

Additionaly, HumanBytes now scales up to Yobibytes instead of only Tebibytes.

This introduces a new dependency on the number_prefix crate (MIT licensed).