### PR TITLE
Add a constructor taking a ProgressDrawTarget

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -434,8 +434,8 @@ pub struct ProgressBar {
 impl ProgressBar {
     /// Creates a new progress bar with a given length.
     ///
-    /// This progress bar by default draws directly to stderr, with a maximum
-    /// refresh rate of 15 hz.
+    /// This progress bar by default draws directly to stderr, and refreshes
+    /// a maximum of 15 times a second
     pub fn new(len: u64) -> ProgressBar {
         ProgressBar::with_draw_target(len, ProgressDrawTarget::stderr())
     }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -434,12 +434,26 @@ pub struct ProgressBar {
 impl ProgressBar {
     /// Creates a new progress bar with a given length.
     ///
-    /// This progress bar by default draws directly to stderr.
+    /// This progress bar by default draws directly to stderr, with a maximum
+    /// refresh rate of 15 hz.
     pub fn new(len: u64) -> ProgressBar {
+        ProgressBar::with_draw_target(len, ProgressDrawTarget::stderr())
+    }
+
+    /// Creates a completely hidden progress bar.
+    ///
+    /// This progress bar still responds to API changes but it does not
+    /// have a length or render in any way.
+    pub fn hidden() -> ProgressBar {
+        ProgressBar::with_draw_target(!0, ProgressDrawTarget::hidden())
+    }
+
+    /// Creates a new progress bar with a given length and draw target.
+    pub fn with_draw_target(len: u64, target: ProgressDrawTarget) -> ProgressBar {
         ProgressBar {
             state: Arc::new(RwLock::new(ProgressState {
                 style: ProgressStyle::default_bar(),
-                draw_target: ProgressDrawTarget::stderr(),
+                draw_target: target,
                 width: None,
                 message: "".into(),
                 prefix: "".into(),
@@ -453,16 +467,6 @@ impl ProgressBar {
                 steady_tick: 0,
             })),
         }
-    }
-
-    /// Creates a completely hidden progress bar.
-    ///
-    /// This progress bar still responds to API changes but it does not
-    /// have a length or render in any way.
-    pub fn hidden() -> ProgressBar {
-        let rv = ProgressBar::new(!0);
-        rv.set_draw_target(ProgressDrawTarget::hidden());
-        rv
     }
 
     /// Creates a new spinner.


### PR DESCRIPTION
Adds a small mention of the refresh rate to `ProgressBar::new` (closes #55). Also adds a convenience constructor to create a ProgressBar with a given draw target.