### PR TITLE
Add option to limit how frequently the progress bar is redrawn

### DIFF
--- a/examples/fastbar.rs
+++ b/examples/fastbar.rs
@@ -1,0 +1,45 @@
+extern crate indicatif;
+
+use std::time::Instant;
+
+use indicatif::{HumanDuration, ProgressBar};
+
+fn many_units_of_easy_work(n: u64, label: &str, draw_delta: Option<u64>) {
+    let pb = ProgressBar::new(n);
+    if let Some(v) = draw_delta {
+        pb.set_draw_delta(v);
+    }
+
+    let mut sum = 0;
+    let started = Instant::now();
+    for i in 0..n {
+        // Any quick computation, followed by an update to the progress bar.
+        sum += 2 * i + 3;
+        pb.inc(1);
+    }
+    pb.finish();
+    let finished = started.elapsed();
+
+    println!(
+        "[{}] Sum ({}) calculated in {}",
+        label,
+        sum,
+        HumanDuration(finished)
+    );
+}
+
+fn main() {
+    const N: u64 = (1 << 20);
+
+    // Perform a long sequence of many simple computations monitored by a
+    // default progress bar.
+    many_units_of_easy_work(N, "Default progress bar ", None);
+
+    // Perform the same sequence of many simple computations, but only redraw
+    // after each 0.005% of additional progress.
+    many_units_of_easy_work(N, "Draw delta is 0.005% ", Some(N / (5 * 100000)));
+
+    // Perform the same sequence of many simple computations, but only redraw
+    // after each 0.01% of additional progress.
+    many_units_of_easy_work(N, "Draw delta is 0.01%  ", Some(N / 10000));
+}

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -530,6 +530,13 @@ impl ProgressBar {
     /// This setting is helpful in situations where the overhead of redrawing
     /// the progress bar dominates the computation whose progress is being
     /// reported.
+    ///
+    /// ```rust,no_run
+    /// # use indicatif::ProgressBar;
+    /// let n = 1_000_000;
+    /// let pb = ProgressBar::new(n);
+    /// pb.set_draw_delta(n / 100); // redraw every 1% of additional progress
+    /// ```
     pub fn set_draw_delta(&self, n: u64) {
         let mut state = self.state.write();
         state.draw_delta = n;

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -340,6 +340,8 @@ struct ProgressState {
     pos: u64,
     len: u64,
     tick: u64,
+    draw_delta: u64,
+    draw_next: u64,
     status: Status,
     started: Instant,
     est: Estimate,
@@ -446,6 +448,8 @@ impl ProgressBar {
                 pos: 0,
                 len: len,
                 tick: 0,
+                draw_delta: 1,
+                draw_next: 1,
                 status: Status::InProgress,
                 started: Instant::now(),
                 est: Estimate::new(),
@@ -518,6 +522,18 @@ impl ProgressBar {
     /// Undoes `enable_steady_tick`.
     pub fn disable_steady_tick(&self) {
         self.enable_steady_tick(0);
+    }
+
+    /// Limit redrawing of progress bar to every `n` steps.
+    ///
+    /// By default, the progress bar will redraw whenever its state advances.
+    /// This setting is helpful in situations where the overhead of redrawing
+    /// the progress bar dominates the computation whose progress is being
+    /// reported.
+    pub fn set_draw_delta(&self, n: u64) {
+        let mut state = self.state.write();
+        state.draw_delta = n;
+        state.draw_next = state.pos + state.draw_delta;
     }
 
     /// Manually ticks the spinner or progress bar.
@@ -603,6 +619,7 @@ impl ProgressBar {
     pub fn finish(&self) {
         self.update_and_draw(|state| {
             state.pos = state.len;
+            state.draw_next = state.pos;
             state.status = Status::DoneVisible;
         });
     }
@@ -613,6 +630,7 @@ impl ProgressBar {
         self.update_and_draw(|state| {
             state.message = msg;
             state.pos = state.len;
+            state.draw_next = state.pos;
             state.status = Status::DoneVisible;
         });
     }
@@ -621,6 +639,7 @@ impl ProgressBar {
     pub fn finish_and_clear(&self) {
         self.update_and_draw(|state| {
             state.pos = state.len;
+            state.draw_next = state.pos;
             state.status = Status::DoneHidden;
         });
     }
@@ -657,6 +676,7 @@ impl ProgressBar {
     }
 
     fn update_and_draw<F: FnOnce(&mut ProgressState)>(&self, f: F) {
+        let mut draw = false;
         {
             let mut state = self.state.write();
             let old_pos = state.pos;
@@ -665,8 +685,14 @@ impl ProgressBar {
             if new_pos != old_pos {
                 state.est.record_step(new_pos);
             }
+            if new_pos >= state.draw_next {
+                state.draw_next = new_pos + state.draw_delta;
+                draw = true;
+            }
         }
-        self.draw().ok();
+        if draw {
+            self.draw().ok();
+        }
     }
 
     fn draw(&self) -> io::Result<()> {


### PR DESCRIPTION
The default behavior seems to be to redraw the progress bar with any triggered update of the state (for example, using `inc(i)`, `set_position(i)`, etc).  For situations where the number of items being processed is very large, but the actual time to process each item is very small, the drawing of the progress bar dominates the overall computation time.

This pull request adds a method `set_draw_delta(n)` which limits the redrawing of the progress bar to every `n` steps, but allows the user to still call methods to update the position.  The default behavior of updating the progress bar with every update remains the same.  An example of the usage of `set_draw_delta(n)` is included which demonstrates that drawing too frequently can have significant overhead to an overall computation.  Output of one run of the example is below.

<img width="553" alt="fastbar rs output" src="https://user-images.githubusercontent.com/1234/43681200-41735602-9802-11e8-8e0b-e2ba9d2355e6.png">
