### PR TITLE
add coverage support into travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 language: rust
 rust:
   - stable
@@ -6,3 +6,8 @@ rust:
 
 script:
   - cargo test
+after_success:
+  - |
+    RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install --force --git https://github.com/xd009642/tarpaulin --tag 0.6.6 cargo-tarpaulin
+    cargo tarpaulin --out Xml --no-count
+    bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # indicatif
 [![build status](https://travis-ci.org/mitsuhiko/indicatif.svg?branch=master)](https://travis-ci.org/mitsuhiko/indicatif)
 [![Crates.io](https://img.shields.io/crates/v/indicatif.svg)](https://crates.io/crates/indicatif)
+[![codecov](https://codecov.io/gh/mitsuhiko/indicatif/branch/master/graph/badge.svg)](https://codecov.io/gh/mitsuhiko/indicatif)
 
 [Documentation](https://docs.rs/indicatif)
 


### PR DESCRIPTION
* add coverage support into travis configuration
* add badge with codecov

Example of codecov report: https://codecov.io/gh/AnderEnder/indicatif/branch/coverage

P.S. cargo tarpaulin moved to experimental, so I pinned the version to latest stable.