### PR TITLE
Refactor iterator API, add Rayon extension

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ regex = "1"
 lazy_static = "1"
 number_prefix = "0.2"
 console = ">=0.7.1, <1.0.0"
-rayon = {version = "1.0.3", optional = true}
+rayon = {version = "1.0", optional = true}
 
 [dev-dependencies]
 rand = "0"
@@ -25,4 +25,4 @@ tokio-core = "0.1"
 
 [features]
 default = []
-indicatif-rayon = ["rayon"]
+with_rayon = ["rayon"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,13 @@ regex = "1"
 lazy_static = "1"
 number_prefix = "0.2"
 console = ">=0.7.1, <1.0.0"
+rayon = {version = "1.0.3", optional = true}
 
 [dev-dependencies]
 rand = "0"
 futures = "0.1"
 tokio-core = "0.1"
+
+[features]
+default = []
+indicatif-rayon = ["rayon"]

--- a/examples/iterator.rs
+++ b/examples/iterator.rs
@@ -1,0 +1,24 @@
+extern crate indicatif;
+
+use indicatif::{ProgressBar, ProgressIterator, ProgressStyle};
+
+fn main() {
+    // Default styling, attempt to use Iterator::size_hint to count input size
+    for _ in (0..1000).progress() {
+        // ...
+    }
+
+    // Provide explicit number of elements in iterator
+    for _ in (0..1000).progress_count(1000) {
+        // ...
+    }
+
+    // Provide a custom bar style
+    let pb = ProgressBar::new(1000);
+    pb.set_style(ProgressStyle::default_bar().template(
+        "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] ({pos}/{len}, ETA {eta})",
+    ));
+    for _ in (0..1000).progress_with(pb) {
+        // ...
+    }
+}

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -64,6 +64,10 @@ pub mod rayon {
         progress: Arc<Mutex<ProgressBar>>,
     }
 
+    /// Wraps a Rayon parallel iterator.
+    ///
+    /// See [`ProgressIterator`](trait.ProgressIterator.html) for method
+    /// documentation.
     pub trait ParallelProgressIterator
     where
         Self: Sized,

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -5,12 +5,8 @@ pub trait ProgressIterator
 where
     Self: Sized + Iterator,
 {
-    fn progress_with(self, progress: ProgressBar) -> ProgressBarIter<Self>;
-
-    fn progress_count(self, len: u64) -> ProgressBarIter<Self> {
-        self.progress_with(ProgressBar::new(len))
-    }
-
+    /// Wrap an iterator with default styling. Attempt to guess iterator
+    /// length using `Iterator::size_hint`.
     fn progress(self) -> ProgressBarIter<Self> {
         let n = match self.size_hint() {
             (_, Some(n)) => n as u64,
@@ -18,6 +14,14 @@ where
         };
         self.progress_count(n)
     }
+
+    /// Wrap an iterator with an explicit element count.
+    fn progress_count(self, len: u64) -> ProgressBarIter<Self> {
+        self.progress_with(ProgressBar::new(len))
+    }
+
+    /// Wrap an iterator with a custom progress bar.
+    fn progress_with(self, progress: ProgressBar) -> ProgressBarIter<Self>;
 }
 
 /// Wraps an iterator to display its progress.

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,5 +1,6 @@
 use progress::ProgressBar;
 
+/// Wraps an iterator to display its progress.
 pub trait ProgressIterator
 where
     Self: Sized + Iterator,
@@ -19,6 +20,7 @@ where
     }
 }
 
+/// Wraps an iterator to display its progress.
 pub struct ProgressBarIter<T> {
     it: T,
     progress: ProgressBar,

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,0 +1,184 @@
+use progress::ProgressBar;
+
+macro_rules! progress_iterator_trait {
+    ($trait:ident , $struct:ident) => {
+        pub trait $trait
+        where
+            Self: Sized,
+        {
+            fn progress_with(self, progress: ProgressBar) -> $struct<Self>;
+
+            fn progress_count(self, len: u64) -> $struct<Self> {
+                self.progress_with(ProgressBar::new(len))
+            }
+
+            fn progress(self) -> $struct<Self> {
+                self.progress_count(0)
+            }
+        }
+    };
+}
+
+progress_iterator_trait! { ProgressIterator, ProgressBarIter }
+
+pub struct ProgressBarIter<T> {
+    it: T,
+    progress: ProgressBar,
+}
+
+impl<S, T: Iterator<Item = S>> Iterator for ProgressBarIter<T> {
+    type Item = S;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = self.it.next();
+
+        if next.is_some() {
+            self.progress.inc(1);
+        } else {
+            self.progress.finish();
+        }
+
+        next
+    }
+}
+
+impl<S, T: Iterator<Item = S>> ProgressIterator for T {
+    fn progress_with(self, progress: ProgressBar) -> ProgressBarIter<Self> {
+        ProgressBarIter { it: self, progress }
+    }
+}
+
+#[cfg(feature = "indicatif-rayon")]
+pub mod rayon {
+    use super::*;
+    use rayon::iter::{
+        plumbing::Consumer, plumbing::Folder, plumbing::UnindexedConsumer, ParallelIterator,
+    };
+    use std::sync::{Arc, Mutex};
+    pub struct ParProgressBarIter<T> {
+        it: T,
+        progress: Arc<Mutex<ProgressBar>>,
+    }
+
+    progress_iterator_trait! { ParallelProgressIterator, ParProgressBarIter }
+
+    impl<S: Send, T: ParallelIterator<Item = S>> ParallelProgressIterator for T {
+        fn progress_with(self, progress: ProgressBar) -> ParProgressBarIter<Self> {
+            ParProgressBarIter {
+                it: self,
+                progress: Arc::new(Mutex::new(progress)),
+            }
+        }
+    }
+
+    struct ProgressConsumer<C> {
+        base: C,
+        progress: Arc<Mutex<ProgressBar>>,
+    }
+
+    impl<C> ProgressConsumer<C> {
+        fn new(base: C, progress: Arc<Mutex<ProgressBar>>) -> Self {
+            ProgressConsumer { base, progress }
+        }
+    }
+
+    impl<T, C: Consumer<T>> Consumer<T> for ProgressConsumer<C> {
+        type Folder = ProgressFolder<C::Folder>;
+        type Reducer = C::Reducer;
+        type Result = C::Result;
+
+        fn split_at(self, index: usize) -> (Self, Self, Self::Reducer) {
+            let (left, right, reducer) = self.base.split_at(index);
+            (
+                ProgressConsumer::new(left, self.progress.clone()),
+                ProgressConsumer::new(right, self.progress.clone()),
+                reducer,
+            )
+        }
+
+        fn into_folder(self) -> Self::Folder {
+            ProgressFolder {
+                base: self.base.into_folder(),
+                progress: self.progress.clone(),
+            }
+        }
+
+        fn full(&self) -> bool {
+            self.base.full()
+        }
+    }
+
+    impl<T, C: UnindexedConsumer<T>> UnindexedConsumer<T> for ProgressConsumer<C> {
+        fn split_off_left(&self) -> Self {
+            ProgressConsumer::new(self.base.split_off_left(), self.progress.clone())
+        }
+
+        fn to_reducer(&self) -> Self::Reducer {
+            self.base.to_reducer()
+        }
+    }
+
+    struct ProgressFolder<C> {
+        base: C,
+        progress: Arc<Mutex<ProgressBar>>,
+    }
+
+    impl<T, C: Folder<T>> Folder<T> for ProgressFolder<C> {
+        type Result = C::Result;
+
+        fn consume(self, item: T) -> Self {
+            self.progress.lock().unwrap().inc(1);
+            ProgressFolder {
+                base: self.base.consume(item),
+                progress: self.progress,
+            }
+        }
+
+        fn complete(self) -> C::Result {
+            self.base.complete()
+        }
+
+        fn full(&self) -> bool {
+            self.base.full()
+        }
+    }
+
+    impl<S: Send, T: ParallelIterator<Item = S>> ParallelIterator for ParProgressBarIter<T> {
+        type Item = S;
+
+        fn drive_unindexed<C: UnindexedConsumer<Self::Item>>(self, consumer: C) -> C::Result {
+            let consumer1 = ProgressConsumer::new(consumer, self.progress.clone());
+            self.it.drive_unindexed(consumer1)
+        }
+    }
+
+    #[cfg(test)]
+    mod test {
+        use iter::{rayon::ParallelProgressIterator, ProgressIterator};
+        use progress::ProgressBar;
+        use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+
+        #[test]
+        fn it_can_wrap_a_parallel_iterator() {
+            let v = vec![1, 2, 3];
+            let pb = ProgressBar::new(v.len() as u64);
+            let w: Vec<_> = v.par_iter().progress_with(pb).map(|x| x * 2).collect();
+            assert_eq!(w, vec![2, 4, 6]);
+        }
+
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use iter::ProgressIterator;
+    use progress::ProgressBar;
+
+    #[test]
+    fn it_can_wrap_an_iterator() {
+        let v = vec![1, 2, 3];
+        let pb = ProgressBar::new(v.len() as u64);
+        let w: Vec<_> = v.iter().progress_with(pb).map(|x| x * 2).collect();
+        assert_eq!(w, vec![2, 4, 6]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,7 @@ extern crate lazy_static;
 extern crate console;
 extern crate number_prefix;
 
-#[cfg(feature = "indicatif-rayon")]
+#[cfg(feature = "with_rayon")]
 extern crate rayon;
 
 mod format;
@@ -158,5 +158,5 @@ pub use progress::{
 };
 pub use iter::{ProgressIterator, ProgressBarIter};
 
-#[cfg(feature = "indicatif-rayon")]
-pub use iter::rayon::ParProgressBarIter;
+#[cfg(feature = "with_rayon")]
+pub use iter::rayon::{ParProgressBarIter, ParallelProgressIterator};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,8 @@
 //!
 //! And then use it like this:
 //!
-//! ```rust
+//! ```rust,ignore
+//! # extern crate rayon;
 //! use indicatif::ParallelProgressIterator;
 //! use rayon::iter::{ParallelIterator, IntoParallelRefIterator};
 //!
@@ -182,16 +183,15 @@ extern crate number_prefix;
 extern crate rayon;
 
 mod format;
+mod iter;
 mod progress;
 mod utils;
-mod iter;
 
 pub use format::{BinaryBytes, DecimalBytes, FormattedDuration, HumanBytes, HumanDuration};
+pub use iter::{ProgressBarIter, ProgressIterator};
 pub use progress::{
     MultiProgress, ProgressBar, ProgressBarRead, ProgressDrawTarget, ProgressStyle,
-    MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle,
 };
-pub use iter::{ProgressIterator, ProgressBarIter};
 
 #[cfg(feature = "with_rayon")]
 pub use iter::rayon::{ParProgressBarIter, ParallelProgressIterator};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,11 +143,20 @@ extern crate lazy_static;
 extern crate console;
 extern crate number_prefix;
 
+#[cfg(feature = "indicatif-rayon")]
+extern crate rayon;
+
 mod format;
 mod progress;
 mod utils;
+mod iter;
 
 pub use format::{BinaryBytes, DecimalBytes, FormattedDuration, HumanBytes, HumanDuration};
 pub use progress::{
-    MultiProgress, ProgressBar, ProgressBarIter, ProgressBarRead, ProgressDrawTarget, ProgressStyle,
+    MultiProgress, ProgressBar, ProgressBarRead, ProgressDrawTarget, ProgressStyle,
+    MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle,
 };
+pub use iter::{ProgressIterator, ProgressBarIter};
+
+#[cfg(feature = "indicatif-rayon")]
+pub use iter::rayon::ParProgressBarIter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,41 @@
 //!   a new message / retaining the current message.
 //! * the default template renders neither message nor prefix.
 //!
+//! # Iterators
+//!
+//! Similar to [tqdm](https://github.com/tqdm/tqdm), progress bars can be
+//! associated with an iterator. For example:
+//!
+//! ```rust
+//! use indicatif::ProgressIterator;
+//!
+//! for _ in (0..1000).progress() {
+//!     // ...
+//! }
+//! ```
+//!
+//! See the [`ProgressIterator`](trait.ProgressIterator.html) trait for more
+//! methods to configure the number of elements in the iterator or change
+//! the progress bar style. Indicatif also has optional support for parallel
+//! iterators with [Rayon](https://github.com/rayon-rs/rayon). In your
+//! `cargo.toml`, use the "with_rayon" feature:
+//!
+//! ```toml
+//! [dependencies]
+//! indicatif = {version = "*", features = ["with_rayon"]}
+//! ```
+//!
+//! And then use it like this:
+//!
+//! ```rust
+//! use indicatif::ParallelProgressIterator;
+//! use rayon::iter::{ParallelIterator, IntoParallelRefIterator};
+//!
+//! let v: Vec<_> = (0..100000).collect();
+//! let v2: Vec<_> = v.par_iter().progress().map(|i| i + 1).collect();
+//! assert_eq!(v2[0], 1);
+//! ```
+//!
 //! # Templates
 //!
 //! Progress bars can be styled with simple format strings similar to the

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -700,20 +700,6 @@ impl ProgressBar {
         self.state.write().draw_target = target;
     }
 
-    /// Wraps an iterator with the progress bar.
-    ///
-    /// ```rust,norun
-    /// # use indicatif::ProgressBar;
-    /// let v = vec![1, 2, 3];
-    /// let pb = ProgressBar::new(3);
-    /// for item in pb.wrap_iter(v.iter()) {
-    ///     // ...
-    /// }
-    /// ```
-    pub fn wrap_iter<It: Iterator>(&self, it: It) -> ProgressBarIter<It> {
-        ProgressBarIter { bar: self, it: it }
-    }
-
     /// Wraps a Reader with the progress bar.
     ///
     /// ```rust,norun
@@ -971,27 +957,6 @@ impl Drop for ProgressBar {
     }
 }
 
-/// Iterator for `wrap_iter`.
-#[derive(Debug)]
-pub struct ProgressBarIter<'a, I> {
-    bar: &'a ProgressBar,
-    it: I,
-}
-
-impl<'a, I: Iterator> Iterator for ProgressBarIter<'a, I> {
-    type Item = I::Item;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let item = self.it.next();
-
-        if item.is_some() {
-            self.bar.inc(1);
-        }
-
-        item
-    }
-}
-
 /// Reader for `wrap_read`.
 #[derive(Debug)]
 pub struct ProgressBarRead<'a, R> {
@@ -1012,14 +977,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn it_can_wrap_an_iterator() {
-        let v = vec![1, 2, 3];
-        let pb = ProgressBar::new(v.len() as u64);
-        let w: Vec<_> = pb.wrap_iter(v.iter()).map(|x| x * 2).collect();
-        assert_eq!(w, vec![2, 4, 6]);
-    }
-
-    #[test]
     fn it_can_wrap_a_reader() {
         let bytes = &b"I am an implementation of io::Read"[..];
         let pb = ProgressBar::new(bytes.len() as u64);
@@ -1029,7 +986,6 @@ mod tests {
         assert_eq!(writer, bytes);
     }
 
-    #[test]
     fn progress_bar_sync_send() {
         let _: Box<Sync> = Box::new(ProgressBar::new(1));
         let _: Box<Send> = Box::new(ProgressBar::new(1));


### PR DESCRIPTION
While using indicatif, I had modified the iterator API to both a) work with iterator chaining and b) support parallel iterators with Rayon. The changes look like:

```rust
let mut v = vec![1, 2, 3];

// used to be:
let pb = ProgressBar::new(v.len());
for item in pb.wrap_iter(v.iter()) {
  ...
}

// now is:
for item in v.iter().progress_count(v.len()) {
  ...
}

// also parallel iterators
v.par_iter().progress().map(|i| { ... }).collect()
```

I added a feature gate so the user does not have to download Rayon if they're not using it.

I wanted to show this initial PR to see if the maintainers would be interested in either change. If so, I can go ahead and add more tests/documentation.