### PR TITLE
[steady_tick] Fix steady tick getting stuck after disabling and re-enabling.

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -531,6 +531,7 @@ impl ProgressBar {
                 let mut state = state_arc.write();
                 if state.is_finished() || state.steady_tick == 0 {
                     state.steady_tick = 0;
+                    state.tick_thread = None;
                     break;
                 }
                 if state.tick != 0 {


### PR DESCRIPTION
Upon exiting the steady tick thread, we don't ever set `tick_thread` back to None, so nothing starts it up again! 