### PR TITLE
build fix for rust <= v1.30

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -545,7 +545,7 @@ impl ProgressBar {
         }));
 
         // use the sideeffect of tick to force the bar to tick.
-        std::mem::drop(state);
+        ::std::mem::drop(state);
         self.tick();
     }
 


### PR DESCRIPTION
Thanks for this project! I’m using this for a [python sampling profiler](https://github.com/benfred/py-spy) I’ve been working on, and it is has been working out great.

When compiling v0.10.3 using rust v1.29, I got this build error:

```
error[E0658]: access to extern crates through prelude is experimental (see issue #44660)
   --> /Users/ben/.cargo/registry/src/github.com-1ecc6299db9ec823/indicatif-0.10.3/src/progress.rs:548:9
    |
548 |         std::mem::drop(state);
    |         ^^^
```

I think this was caused by this commit here: https://github.com/mitsuhiko/indicatif/commit/fc57e15841137f68d3d70ff30382fc80883af0bd#diff-2731f87d144f80edb31dac3d81fd9107

I realize that this builds with the latest rust, but I have some people using older versions of rust
to package up my project (https://github.com/benfred/py-spy/issues/18) and I'd like to support them.

This PR fixes so that indicatif will build on rust <= 1.30