### PR TITLE
Add ProgressBar::with_style convenience function

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -331,6 +331,12 @@ impl ProgressBar {
         }
     }
 
+    /// A convenience builder-like function for a progress bar with a given style.
+    pub fn with_style(self, style: ProgressStyle) -> ProgressBar {
+        self.state.write().style = style;
+        self
+    }
+
     /// Creates a new spinner.
     ///
     /// This spinner by default draws directly to stderr  This adds the


### PR DESCRIPTION
This adds a convenience function to `ProgressBar`. It imitates a builder function and is intended to be used as `ProgressBar::new(1234).with_style(...)`.