### PR TITLE
Prefer Into<String> over &str

### DIFF
--- a/examples/finebars.rs
+++ b/examples/finebars.rs
@@ -19,7 +19,7 @@ fn main() {
         let pb = m.add(ProgressBar::new(512));
         pb.set_style(
             ProgressStyle::default_bar()
-                .template(&format!("{{prefix:.bold}}▕{{bar:.{}}}▏{{msg}}", s.2))
+                .template(format!("{{prefix:.bold}}▕{{bar:.{}}}▏{{msg}}", s.2))
                 .progress_chars(s.1),
         );
         pb.set_prefix(s.0);
@@ -27,7 +27,7 @@ fn main() {
         thread::spawn(move || {
             for i in 0..512 {
                 pb.inc(1);
-                pb.set_message(&format!("{:3}%", 100 * i / 512));
+                pb.set_message(format!("{:3}%", 100 * i / 512));
                 thread::sleep(wait);
             }
             pb.finish_with_message("100%");

--- a/examples/multi.rs
+++ b/examples/multi.rs
@@ -13,7 +13,7 @@ fn main() {
     pb.set_style(sty.clone());
     let _ = thread::spawn(move || {
         for i in 0..128 {
-            pb.set_message(&format!("item #{}", i + 1));
+            pb.set_message(format!("item #{}", i + 1));
             pb.inc(1);
             thread::sleep(Duration::from_millis(15));
         }
@@ -26,7 +26,7 @@ fn main() {
         for _ in 0..3 {
             pb.set_position(0);
             for i in 0..128 {
-                pb.set_message(&format!("item #{}", i + 1));
+                pb.set_message(format!("item #{}", i + 1));
                 pb.inc(1);
                 thread::sleep(Duration::from_millis(8));
             }
@@ -38,7 +38,7 @@ fn main() {
     pb.set_style(sty.clone());
     let _ = thread::spawn(move || {
         for i in 0..1024 {
-            pb.set_message(&format!("item #{}", i + 1));
+            pb.set_message(format!("item #{}", i + 1));
             pb.inc(1);
             thread::sleep(Duration::from_millis(2));
         }

--- a/examples/yarnish.rs
+++ b/examples/yarnish.rs
@@ -75,13 +75,13 @@ pub fn main() {
         let count = rng.gen_range(30, 80);
         let pb = m.add(ProgressBar::new(count));
         pb.set_style(spinner_style.clone());
-        pb.set_prefix(&format!("[{}/?]", i + 1));
+        pb.set_prefix(format!("[{}/?]", i + 1));
         let _ = thread::spawn(move || {
             let mut rng = rand::thread_rng();
             let pkg = PACKAGES.choose(&mut rng).unwrap();
             for _ in 0..count {
                 let cmd = COMMANDS.choose(&mut rng).unwrap();
-                pb.set_message(&format!("{}: {}", pkg, cmd));
+                pb.set_message(format!("{}: {}", pkg, cmd));
                 pb.inc(1);
                 thread::sleep(Duration::from_millis(rng.gen_range(25, 200)));
             }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -567,8 +567,8 @@ impl ProgressBar {
     ///
     /// For the prefix to be visible, `{prefix}` placeholder
     /// must be present in the template (see `ProgressStyle`).
-    pub fn set_prefix(&self, prefix: &str) {
-        let prefix = prefix.to_string();
+    pub fn set_prefix<I: Into<String>>(&self, prefix: I) {
+        let prefix = prefix.into();
         self.update_and_draw(|state| {
             state.prefix = prefix;
             if state.steady_tick == 0 || state.tick == 0 {
@@ -581,8 +581,8 @@ impl ProgressBar {
     ///
     /// For the message to be visible, `{msg}` placeholder
     /// must be present in the template (see `ProgressStyle`).
-    pub fn set_message(&self, msg: &str) {
-        let msg = msg.to_string();
+    pub fn set_message<I: Into<String>>(&self, msg: I) {
+        let msg = msg.into();
         self.update_and_draw(|state| {
             state.message = msg;
             if state.steady_tick == 0 || state.tick == 0 {
@@ -639,8 +639,8 @@ impl ProgressBar {
     ///
     /// For the message to be visible, `{msg}` placeholder
     /// must be present in the template (see `ProgressStyle`).
-    pub fn finish_with_message(&self, msg: &str) {
-        let msg = msg.to_string();
+    pub fn finish_with_message<I: Into<String>>(&self, msg: I) {
+        let msg = msg.into();
         self.update_and_draw(|state| {
             state.message = msg;
             state.pos = state.len;

--- a/src/style.rs
+++ b/src/style.rs
@@ -60,8 +60,8 @@ impl ProgressStyle {
     }
 
     /// Sets the template string for the progress bar.
-    pub fn template(mut self, s: &str) -> ProgressStyle {
-        self.template = Cow::Owned(s.into());
+    pub fn template<I: Into<Cow<'static, str>>>(mut self, s: I) -> ProgressStyle {
+        self.template = s.into();
         self
     }
 


### PR DESCRIPTION
Provides better ergonomics when working with indicatif's API.