### PR TITLE
fix: should redraw progress bar after set position

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -509,6 +509,7 @@ impl ProgressBar {
     /// Sets the position of the progress bar.
     pub fn set_position(&self, pos: u64) {
         self.update_and_draw(|state| {
+            state.draw_next = pos;
             state.pos = pos;
             if state.steady_tick == 0 || state.tick == 0 {
                 state.tick = state.tick.saturating_add(1);


### PR DESCRIPTION
`multi` example is broken after #59 , it doesn't redraw the progress bar after set position to 0.