### PR TITLE
Add style key for speed in steps/bytes per second

### DIFF
--- a/examples/download-speed.rs
+++ b/examples/download-speed.rs
@@ -1,0 +1,24 @@
+use std::cmp::min;
+use std::thread;
+use std::time::Duration;
+
+use indicatif::{ProgressBar, ProgressStyle};
+
+fn main() {
+    let mut downloaded = 0;
+    let total_size = 231231231;
+
+    let pb = ProgressBar::new(total_size);
+    pb.set_style(ProgressStyle::default_bar()
+        .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({bytes_per_sec}, {eta})")
+        .progress_chars("#>-"));
+
+    while downloaded < total_size {
+        let new = min(downloaded + 223211, total_size);
+        downloaded = new;
+        pb.set_position(new);
+        thread::sleep(Duration::from_millis(12));
+    }
+
+    pb.finish_with_message("downloaded");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,8 @@
 //! * `total_bytes`: renders the total length of the bar as bytes.
 //! * `elapsed_precise`: renders the elapsed time as `HH:MM:SS`.
 //! * `elapsed`: renders the elapsed time as `42s`, `1m` etc.
+//! * `per_sec`: renders the speed in steps per second.
+//! * `bytes_per_sec`: renders the speed in bytes per second.
 //! * `eta_precise`: the remaining time (like `elapsed_precise`).
 //! * `eta`: the remaining time (like `elapsed`).
 //!

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -302,6 +302,16 @@ impl ProgressState {
         // add 0.75 to leave 0.25 sec of 0s for the user
         secs_to_duration(t * self.len.saturating_sub(self.pos) as f64 + 0.75)
     }
+
+    /// The number of steps per second
+    pub fn per_sec(&self) -> u64 {
+        let avg_time = self.avg_time_per_step().as_nanos();
+        if avg_time == 0 {
+            0
+        } else {
+            (1_000_000_000 / avg_time) as u64
+        }
+    }
 }
 
 /// A progress bar or spinner.

--- a/src/style.rs
+++ b/src/style.rs
@@ -142,6 +142,8 @@ impl ProgressStyle {
                     "binary_total_bytes" => format!("{}", BinaryBytes(state.len)),
                     "elapsed_precise" => format!("{}", FormattedDuration(state.started.elapsed())),
                     "elapsed" => format!("{:#}", HumanDuration(state.started.elapsed())),
+                    "per_sec" => format!("{}/s", state.per_sec()),
+                    "bytes_per_sec" => format!("{}/s", HumanBytes(state.per_sec())),
                     "eta_precise" => format!("{}", FormattedDuration(state.eta())),
                     "eta" => format!("{:#}", HumanDuration(state.eta())),
                     _ => "".into(),


### PR DESCRIPTION
This allows printing progress bars like:
```
 [00:00:01] [###>------------------------------------] 18.31MB/220.52MB (15.14MB/s, 14s)
```