### PR TITLE
Added draw targets which simply write text to stderr or stdout.

### DIFF
--- a/examples/yarnish.rs
+++ b/examples/yarnish.rs
@@ -1,7 +1,7 @@
 use rand;
 
-use rand::Rng;
 use rand::seq::SliceRandom;
+use rand::Rng;
 use std::thread;
 use std::time::{Duration, Instant};
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -177,7 +177,7 @@ pub mod rayon_support {
     #[cfg(test)]
     mod test {
         use super::ParProgressBarIter;
-        use crate::iter::rayon_support::{ParallelProgressIterator};
+        use crate::iter::rayon_support::ParallelProgressIterator;
         use crate::progress::ProgressBar;
         use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -195,7 +195,6 @@ pub mod rayon_support {
                 v.par_iter().progress_with(pb)
             });
         }
-
     }
 }
 

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -228,7 +228,11 @@ impl ProgressDrawState {
     }
 
     pub fn draw_to_text(&self, use_stderr: bool) -> io::Result<()> {
-        let mut out: Box<dyn io::Write> = if use_stderr { Box::new(io::stderr()) } else { Box::new(io::stdout()) };
+        let mut out: Box<dyn io::Write> = if use_stderr {
+            Box::new(io::stderr())
+        } else {
+            Box::new(io::stdout())
+        };
         for line in &self.lines {
             out.write_all(line.as_bytes())?;
             out.write_all(b"\n")?;

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -228,7 +228,7 @@ impl ProgressDrawState {
     }
 
     pub fn draw_to_text(&self, use_stderr: bool) -> io::Result<()> {
-        let mut out: Box<io::Write> = if use_stderr { Box::new(io::stderr()) } else { Box::new(io::stdout()) };
+        let mut out: Box<dyn io::Write> = if use_stderr { Box::new(io::stderr()) } else { Box::new(io::stdout()) };
         for line in &self.lines {
             out.write_all(line.as_bytes())?;
             out.write_all(b"\n")?;

--- a/src/style.rs
+++ b/src/style.rs
@@ -19,9 +19,7 @@ impl ProgressStyle {
     /// Returns the default progress bar style for bars.
     pub fn default_bar() -> ProgressStyle {
         ProgressStyle {
-            tick_chars: "⠁⠁⠉⠙⠚⠒⠂⠂⠒⠲⠴⠤⠄⠄⠤⠠⠠⠤⠦⠖⠒⠐⠐⠒⠓⠋⠉⠈⠈ "
-                .chars()
-                .collect(),
+            tick_chars: "⠁⠁⠉⠙⠚⠒⠂⠂⠒⠲⠴⠤⠄⠄⠤⠠⠠⠤⠦⠖⠒⠐⠐⠒⠓⠋⠉⠈⠈ ".chars().collect(),
             progress_chars: "█░".chars().collect(),
             template: Cow::Borrowed("{wide_bar} {pos}/{len}"),
         }
@@ -30,9 +28,7 @@ impl ProgressStyle {
     /// Returns the default progress bar style for spinners.
     pub fn default_spinner() -> ProgressStyle {
         ProgressStyle {
-            tick_chars: "⠁⠁⠉⠙⠚⠒⠂⠂⠒⠲⠴⠤⠄⠄⠤⠠⠠⠤⠦⠖⠒⠐⠐⠒⠓⠋⠉⠈⠈ "
-                .chars()
-                .collect(),
+            tick_chars: "⠁⠁⠉⠙⠚⠒⠂⠂⠒⠲⠴⠤⠄⠄⠤⠠⠠⠤⠦⠖⠒⠐⠐⠒⠓⠋⠉⠈⠈ ".chars().collect(),
             progress_chars: "█░".chars().collect(),
             template: Cow::Borrowed("{spinner} {msg}"),
         }


### PR DESCRIPTION
I wanted to use indicatif's great styling but see the progress as a stream of lines of text instead of a transient single line. This might also be useful in cases when a terminal is not available, like logging to a file.

It adds a ProgressDrawTargetKind::Text(bool) with the boolean indicating whether to use stderr or stdout, and the handlers to match this new kind.  Since progress updates can be made to both the amount and the message, the manual_tick field  was also added to limit the output to only when tick() is called, rather than on each update_and_draw.
