### PR TITLE
Support increasing the length of the progress bar with a delta.

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -523,6 +523,13 @@ impl ProgressBar {
         })
     }
 
+    /// Increase the length of the progress bar.
+    pub fn inc_length(&self, delta: u64) {
+        self.update_and_draw(|state| {
+            state.len = state.len.saturating_add(delta);
+        })
+    }
+
     /// Sets the current prefix of the progress bar.
     pub fn set_prefix(&self, prefix: &str) {
         let prefix = prefix.to_string();


### PR DESCRIPTION
This is useful when new work arrives while tracking the progress of existing work.