### PR TITLE
I needed to leave a progress bar on screen that had not completed to 100% due to errors.

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -571,6 +571,14 @@ impl ProgressBar {
         });
     }
 
+    /// Finishes the progress bar at current position and leaves the current message.
+    pub fn finish_at_current_pos(&self) {
+        self.update_and_draw(|state| {
+            state.draw_next = state.pos;
+            state.status = Status::DoneVisible;
+        });
+    }
+
     /// Finishes the progress bar and sets a message.
     pub fn finish_with_message(&self, msg: &str) {
         let msg = msg.to_string();


### PR DESCRIPTION
MultiProgressBar join() method requires sub-progress-bars
to finish before join() succeds, but the default finish
method would update the state.pos to 100% obsucring the
fact that the process was incomplete.

I therefore added a new method finsih_at_current_pos()
that updates the state to DoneVisible without changing
the current position. This solves my problem.