### PR TITLE
Only finish the progress bar on last refcount drop

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -436,10 +436,10 @@ impl ProgressBar {
                 }
             }
 
-            draw_state(&state_arc).ok();
+            draw_state(&mut state_arc.write().unwrap()).ok();
         }));
 
-        // use the sideeffect of tick to force the bar to tick.
+        // use the side effect of tick to force the bar to tick.
         ::std::mem::drop(state);
         self.tick();
     }
@@ -720,7 +720,7 @@ impl ProgressBar {
     }
 
     fn draw(&self) -> io::Result<()> {
-        draw_state(&self.state)
+        draw_state(&mut self.state.write().unwrap())
     }
 
     pub fn position(&self) -> u64 {
@@ -728,8 +728,8 @@ impl ProgressBar {
     }
 }
 
-fn draw_state(state: &Arc<RwLock<ProgressState>>) -> io::Result<()> {
-    let mut state = state.write().unwrap();
+fn draw_state(state: &mut ProgressState) -> io::Result<()> {
+    // let mut state = state.write().unwrap();
 
     // we can bail early if the draw target is hidden.
     if state.draw_target.is_hidden() {
@@ -749,6 +749,20 @@ fn draw_state(state: &Arc<RwLock<ProgressState>>) -> io::Result<()> {
         ts: Instant::now(),
     };
     state.draw_target.apply_draw_state(draw_state)
+}
+
+impl Drop for ProgressState {
+    fn drop(&mut self) {
+        if self.is_finished() {
+            return;
+        }
+
+        self.status = Status::DoneHidden;
+        if self.pos >= self.draw_next {
+            self.draw_next = self.pos.saturating_add(self.draw_delta);
+            draw_state(self).ok();
+        }
+    }
 }
 
 #[test]
@@ -976,19 +990,6 @@ impl MultiProgress {
         self.joining.store(false, Ordering::Release);
 
         Ok(())
-    }
-}
-
-impl Drop for ProgressBar {
-    fn drop(&mut self) {
-        if Arc::get_mut(&mut self.state).is_some() {
-            if self.state.read().unwrap().is_finished() {
-                return;
-            }
-            self.update_and_draw(|state| {
-                state.status = Status::DoneHidden;
-            });
-        }
     }
 }
 

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -729,8 +729,6 @@ impl ProgressBar {
 }
 
 fn draw_state(state: &mut ProgressState) -> io::Result<()> {
-    // let mut state = state.write().unwrap();
-
     // we can bail early if the draw target is hidden.
     if state.draw_target.is_hidden() {
         return Ok(());

--- a/tests/multi-autodrop.rs
+++ b/tests/multi-autodrop.rs
@@ -1,0 +1,45 @@
+use std::thread;
+use std::sync::mpsc;
+use std::time::Duration;
+use indicatif::{ProgressBar, MultiProgress};
+
+#[test]
+fn main() {
+    let m = MultiProgress::new();
+    let pb = m.add(ProgressBar::new(10));
+    let (tx, rx) = mpsc::channel();
+
+    // start a thread to drive MultiProgress
+    let h = thread::spawn(move || {
+        m.join().unwrap();
+        tx.send(()).unwrap();
+        println!("Done in thread, droping MultiProgress");
+    });
+
+    {
+        let pb2 = pb.clone();
+        for _ in 0..10 {
+            pb2.inc(1);
+            thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    // make sure anything is done in driver thread
+    thread::sleep(Duration::from_millis(50));
+
+    // the driver thread shouldn't finish
+    rx.try_recv().expect_err("The driver thread shouldn't finish");
+
+    pb.set_message("Done");
+    pb.finish();
+
+    // make sure anything is done in driver thread
+    thread::sleep(Duration::from_millis(50));
+
+    // the driver thread should finish here
+    rx.try_recv().expect("The driver thread should finish");
+
+    h.join().unwrap();
+
+    println!("Done in main");
+}


### PR DESCRIPTION
This is an alternative way to implement this. `Drop` is directly implemented on `ProgressState`, which is IMHO semantically more correct than the current solution: 821ed338e7b648183803cbb0ad118cf12e5a5616.

I also added my example as a proper test case.