### PR TITLE
Allow spinners longer than one character

### DIFF
--- a/examples/long-spinner.rs
+++ b/examples/long-spinner.rs
@@ -1,0 +1,27 @@
+use std::thread;
+use std::time::Duration;
+
+use indicatif::{ProgressBar, ProgressStyle};
+
+fn main() {
+    let pb = ProgressBar::new_spinner();
+    pb.enable_steady_tick(120);
+    pb.set_style(
+        ProgressStyle::default_spinner()
+            // For more spinners check out the cli-spinners project:
+            // https://github.com/sindresorhus/cli-spinners/blob/master/spinners.json
+            .tick_strings(&[
+                "▹▹▹▹▹",
+                "▸▹▹▹▹",
+                "▹▸▹▹▹",
+                "▹▹▸▹▹",
+                "▹▹▹▸▹",
+                "▹▹▹▹▸",
+                "     ",
+            ])
+            .template("{spinner:.blue} {msg}"),
+    );
+    pb.set_message("Calculating...");
+    thread::sleep(Duration::from_secs(5));
+    pb.finish_with_message("Done");
+}

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -195,7 +195,6 @@ pub mod rayon_support {
                 v.par_iter().progress_with(pb)
             });
         }
-
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@
 //!   style string is used to color the elapsed part, the alternative
 //!   style is used for the bar that is yet to render.
 //! * `wide_bar`: like `bar` but always fills the remaining space.
-//! * `spinner`: renders the spinner (current tick char)
+//! * `spinner`: renders the spinner (current tick string).
 //! * `prefix`: renders the prefix set on the progress bar.
 //! * `msg`: renders the currently set message on the progress bar.
 //! * `wide_msg`: like `msg` but always fills the remaining space and truncates.

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -109,12 +109,8 @@ impl ProgressDrawTarget {
     /// terminal is not user attended the entire progress bar will be
     /// hidden.  This is done so that piping to a file will not produce
     /// useless escape codes in that file.
-    pub fn to_term(
-        term: Term,
-        refresh_rate: impl Into<Option<u64>>,
-    ) -> ProgressDrawTarget {
-        let rate = refresh_rate.into()
-            .map(|x| Duration::from_millis(1000 / x));
+    pub fn to_term(term: Term, refresh_rate: impl Into<Option<u64>>) -> ProgressDrawTarget {
+        let rate = refresh_rate.into().map(|x| Duration::from_millis(1000 / x));
         ProgressDrawTarget {
             kind: ProgressDrawTargetKind::Term(term, None, rate),
         }
@@ -238,13 +234,13 @@ pub(crate) struct ProgressState {
 }
 
 impl ProgressState {
-    /// Returns the character that should be drawn for the
-    /// current spinner character.
-    pub fn current_tick_char(&self) -> char {
+    /// Returns the string that should be drawn for the
+    /// current spinner string.
+    pub fn current_tick_str(&self) -> &str {
         if self.is_finished() {
-            self.style.get_final_tick_char()
+            self.style.get_final_tick_str()
         } else {
-            self.style.get_tick_char(self.tick)
+            self.style.get_tick_str(self.tick)
         }
     }
 
@@ -605,7 +601,6 @@ impl ProgressBar {
             state.pos = 0;
             state.status = Status::InProgress;
         });
-
     }
 
     /// Finishes the progress bar and leaves the current message.


### PR DESCRIPTION
First of all hi @mitsuhiko and thank you for this great crate 👍.

I wanted to have the functionality to use wider spinners that support more than one single char at a time. Therefore I switched the `Vec<char>` with a `Vec<String>` and updated related functions accordingly.

Then all the spinners from the [cli-spinners](https://github.com/sindresorhus/cli-spinners/blob/master/spinners.json) project can be supported.

This is also helpful when using emojis as ticker, because some of them consume 2 characters on the console and need to be cleared with two whitespace chars in the end respectively.

I had to deprecate `get_tick_char` and `get_final_tick_char` as there is no good way of trimming down a `str` to a single `char`.