### PR TITLE
Add `binary_bytes_per_second` state formatter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,8 @@
 //! * `elapsed`: renders the elapsed time as `42s`, `1m` etc.
 //! * `per_sec`: renders the speed in steps per second.
 //! * `bytes_per_sec`: renders the speed in bytes per second.
+//! * `binary_bytes_per_sec`: renders the speed in bytes per second using
+//!   power-of-two units, i.e. `MiB`, `KiB`, etc.
 //! * `eta_precise`: the remaining time (like `elapsed_precise`).
 //! * `eta`: the remaining time (like `elapsed`).
 //!

--- a/src/style.rs
+++ b/src/style.rs
@@ -218,6 +218,7 @@ impl ProgressStyle {
                     "elapsed" => format!("{:#}", HumanDuration(state.started.elapsed())),
                     "per_sec" => format!("{}/s", state.per_sec()),
                     "bytes_per_sec" => format!("{}/s", HumanBytes(state.per_sec())),
+                    "binary_bytes_per_sec" => format!("{}/s", BinaryBytes(state.per_sec())),
                     "eta_precise" => format!("{}", FormattedDuration(state.eta())),
                     "eta" => format!("{:#}", HumanDuration(state.eta())),
                     _ => "".into(),


### PR DESCRIPTION
Format bytes per second for human readability using  ISO/IEC prefixes.

I'm using indicatif in a torrent creator[0], and although it's a bit unusual to format data/second with SI prefixes, I'm using SI prefixes in other places, so I'd like to be consistent.

Thanks for this library! My program will have much prettier output because of indicatif.

[0] https://github.com/casey/intermodal