### PR TITLE
Move Instant from ProgressDrawState to ProgressDrawTargetKind::Term

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -23,8 +23,6 @@ struct ProgressDrawState {
     pub force_draw: bool,
     /// True if we should move the cursor up when possible instead of clearing lines.
     pub move_cursor: bool,
-    /// Time when the draw state was created.
-    pub ts: Instant,
 }
 
 #[derive(Debug)]
@@ -35,7 +33,7 @@ enum Status {
 }
 
 enum ProgressDrawTargetKind {
-    Term(Term, Option<ProgressDrawState>, Option<Duration>),
+    Term(Term, Option<ProgressDrawState>, Option<Duration>, Option<Instant>),
     Remote(
         Arc<RwLock<MultiProgressState>>,
         usize,
@@ -115,7 +113,7 @@ impl ProgressDrawTarget {
     pub fn to_term(term: Term, refresh_rate: impl Into<Option<u64>>) -> ProgressDrawTarget {
         let rate = refresh_rate.into().map(|x| Duration::from_millis(1000 / x));
         ProgressDrawTarget {
-            kind: ProgressDrawTargetKind::Term(term, None, rate),
+            kind: ProgressDrawTargetKind::Term(term, None, rate, None),
         }
     }
 
@@ -159,8 +157,7 @@ impl ProgressDrawTarget {
             return Ok(());
         }
         match self.kind {
-            ProgressDrawTargetKind::Term(ref term, ref mut last_state, rate) => {
-                let last_draw = last_state.as_ref().map(|x| x.ts);
+            ProgressDrawTargetKind::Term(ref term, ref mut last_state, rate, ref mut last_draw) => {
                 if draw_state.finished
                     || draw_state.force_draw
                     || rate.is_none()
@@ -177,6 +174,7 @@ impl ProgressDrawTarget {
                     draw_state.draw_to_term(term)?;
                     term.flush()?;
                     *last_state = Some(draw_state);
+                    *last_draw = Some(Instant::now());
                 }
             }
             ProgressDrawTargetKind::Remote(_, idx, ref chan) => {
@@ -194,7 +192,7 @@ impl ProgressDrawTarget {
     /// Properly disconnects from the draw target
     fn disconnect(&self) {
         match self.kind {
-            ProgressDrawTargetKind::Term(_, _, _) => {}
+            ProgressDrawTargetKind::Term(..) => {}
             ProgressDrawTargetKind::Remote(_, idx, ref chan) => {
                 chan.lock()
                     .unwrap()
@@ -206,7 +204,6 @@ impl ProgressDrawTarget {
                             finished: true,
                             force_draw: false,
                             move_cursor: false,
-                            ts: Instant::now(),
                         },
                     ))
                     .ok();
@@ -601,7 +598,6 @@ impl ProgressBar {
             finished: state.is_finished(),
             force_draw: true,
             move_cursor: false,
-            ts: Instant::now(),
         };
 
         state.draw_target.apply_draw_state(draw_state).ok();
@@ -881,7 +877,6 @@ fn draw_state(state: &mut ProgressState) -> io::Result<()> {
         finished: state.is_finished(),
         force_draw: false,
         move_cursor: false,
-        ts: Instant::now(),
     };
     state.draw_target.apply_draw_state(draw_state)
 }
@@ -1141,7 +1136,6 @@ impl MultiProgress {
             } else {
                 self.rx.recv().unwrap()
             };
-            let ts = draw_state.ts;
             force_draw |= draw_state.finished || draw_state.force_draw;
 
             let mut state = self.state.write().unwrap();
@@ -1206,7 +1200,6 @@ impl MultiProgress {
                 force_draw: force_draw || orphan_lines_count > 0,
                 move_cursor,
                 finished,
-                ts,
             })?;
 
             force_draw = false;
@@ -1220,7 +1213,6 @@ impl MultiProgress {
                 finished: true,
                 force_draw: true,
                 move_cursor,
-                ts: Instant::now(),
             })?;
         }
 


### PR DESCRIPTION
I believe it makes more sense for `Instant` to be stored in `ProgressDrawTargetKind::Term`. The `Instant` is used for checking the rate of drawing only. Now, when it is stored in the draw target it is more accurate (as it actually checks the time of the last draw instead of the time when an update was crated) and reduces memory usage.