### PR TITLE
Unicode awareness for progress_chars

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ regex = { version = "1.3.1", default-features = false, features = ["std"] }
 lazy_static = "1.0"
 number_prefix = "0.3"
 console = ">=0.9.1, <1.0.0"
+unicode-segmentation = "1.6.0"
+unicode-width = "0.1.7"
 rayon = { version = "1.0", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ regex = { version = "1.3.1", default-features = false, features = ["std"] }
 lazy_static = "1.0"
 number_prefix = "0.3"
 console = ">=0.9.1, <1.0.0"
-unicode-segmentation = "1.6.0"
-unicode-width = "0.1.7"
+unicode-segmentation = { version = "1.6.0", optional = true }
+unicode-width = { version = "0.1.7", optional = true }
 rayon = { version = "1.0", optional = true }
 
 [dev-dependencies]
@@ -27,4 +27,7 @@ tokio-core = "0.1"
 
 [features]
 default = []
+improved_unicode = ["unicode-segmentation", "unicode-width", "console/unicode-width"]
+
+# Legacy alias for `rayon`
 with_rayon = ["rayon"]

--- a/examples/fastbar.rs
+++ b/examples/fastbar.rs
@@ -27,7 +27,7 @@ fn many_units_of_easy_work(n: u64, label: &str, draw_delta: Option<u64>) {
 }
 
 fn main() {
-    const N: u64 = (1 << 20);
+    const N: u64 = 1 << 20;
 
     // Perform a long sequence of many simple computations monitored by a
     // default progress bar.

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -52,7 +52,7 @@ impl<S, T: Iterator<Item = S>> ProgressIterator for T {
     }
 }
 
-#[cfg(feature = "with_rayon")]
+#[cfg(feature = "rayon")]
 pub mod rayon_support {
     use super::*;
     use rayon::iter::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,11 +84,11 @@
 //! methods to configure the number of elements in the iterator or change
 //! the progress bar style. Indicatif also has optional support for parallel
 //! iterators with [Rayon](https://github.com/rayon-rs/rayon). In your
-//! `cargo.toml`, use the "with_rayon" feature:
+//! `cargo.toml`, use the "rayon" feature:
 //!
 //! ```toml
 //! [dependencies]
-//! indicatif = {version = "*", features = ["with_rayon"]}
+//! indicatif = {version = "*", features = ["rayon"]}
 //! ```
 //!
 //! And then use it like this:
@@ -178,6 +178,11 @@
 //! println!("The file is {} large", HumanBytes(file.size));
 //! println!("The script took {}", HumanDuration(started.elapsed()));
 //! ```
+//!
+//! # Feature Flags
+//!
+//! * `rayon`: adds rayon support
+//! * `improved_unicode`: adds improved unicode support (graphemes, better width calculation)
 
 mod format;
 mod iter;
@@ -190,5 +195,5 @@ pub use crate::iter::{ProgressBarIter, ProgressIterator};
 pub use crate::progress::{MultiProgress, ProgressBar, ProgressBarWrap, ProgressDrawTarget};
 pub use crate::style::ProgressStyle;
 
-#[cfg(feature = "with_rayon")]
+#[cfg(feature = "rayon")]
 pub use iter::rayon_support::{ParProgressBarIter, ParallelProgressIterator};

--- a/src/style.rs
+++ b/src/style.rs
@@ -134,13 +134,11 @@ impl ProgressStyle {
         let fill = fill as usize;
         let head = if pct > 0.0 && fill < width { 1 } else { 0 };
 
-        let pb = repeat(&state.style.progress_chars[0]).take(fill).fold(
-            String::new(),
-            |mut acc, new| {
-                acc.push_str(&new);
-                acc
-            },
-        );
+        let pb: String = repeat(&state.style.progress_chars[0])
+            .take(fill)
+            .map(|b| b.as_ref())
+            .collect();
+
         let cur = if head == 1 {
             let n = state.style.progress_chars.len().saturating_sub(2);
             let cur_char = if n == 0 {
@@ -153,12 +151,10 @@ impl ProgressStyle {
             "".into()
         };
         let bg = width.saturating_sub(fill).saturating_sub(head);
-        let rest = repeat(state.style.progress_chars.last().unwrap())
+        let rest: String = repeat(state.style.progress_chars.last().unwrap())
             .take(bg)
-            .fold(String::new(), |mut acc, new| {
-                acc.push_str(&new);
-                acc
-            });
+            .map(|b| b.as_ref())
+            .collect();
         format!(
             "{}{}{}",
             pb,


### PR DESCRIPTION
previously using two-wide characters as progress chars made the bar overflow.

also aded a bit more unicode-awareness (grapheme-clusters instead of simple chars)

and made the spinner a bit more efficient (Box<str> instead of String) as it never gets modified.