### PR TITLE
replace &str by Into<String>

### DIFF
--- a/examples/fastbar.rs
+++ b/examples/fastbar.rs
@@ -27,7 +27,7 @@ fn many_units_of_easy_work(n: u64, label: &str, draw_delta: Option<u64>) {
 }
 
 fn main() {
-    const N: u64 = (1 << 20);
+    const N: u64 = 1 << 20;
 
     // Perform a long sequence of many simple computations monitored by a
     // default progress bar.

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -567,8 +567,8 @@ impl ProgressBar {
     ///
     /// For the prefix to be visible, `{prefix}` placeholder
     /// must be present in the template (see `ProgressStyle`).
-    pub fn set_prefix(&self, prefix: &str) {
-        let prefix = prefix.to_string();
+    pub fn set_prefix(&self, prefix: impl Into<String>) {
+        let prefix = prefix.into();
         self.update_and_draw(|state| {
             state.prefix = prefix;
             if state.steady_tick == 0 || state.tick == 0 {
@@ -581,8 +581,8 @@ impl ProgressBar {
     ///
     /// For the message to be visible, `{msg}` placeholder
     /// must be present in the template (see `ProgressStyle`).
-    pub fn set_message(&self, msg: &str) {
-        let msg = msg.to_string();
+    pub fn set_message(&self, msg: impl Into<String>) {
+        let msg = msg.into();
         self.update_and_draw(|state| {
             state.message = msg;
             if state.steady_tick == 0 || state.tick == 0 {
@@ -639,8 +639,8 @@ impl ProgressBar {
     ///
     /// For the message to be visible, `{msg}` placeholder
     /// must be present in the template (see `ProgressStyle`).
-    pub fn finish_with_message(&self, msg: &str) {
-        let msg = msg.to_string();
+    pub fn finish_with_message(&self, msg: impl Into<String>) {
+        let msg = msg.into();
         self.update_and_draw(|state| {
             state.message = msg;
             state.pos = state.len;
@@ -669,8 +669,8 @@ impl ProgressBar {
     ///
     /// For the message to be visible, `{msg}` placeholder
     /// must be present in the template (see `ProgressStyle`).
-    pub fn abandon_with_message(&self, msg: &str) {
-        let msg = msg.to_string();
+    pub fn abandon_with_message(&self, msg: impl Into<String>) {
+        let msg = msg.into();
         self.update_and_draw(|state| {
             state.message = msg;
             state.status = Status::DoneVisible;

--- a/src/style.rs
+++ b/src/style.rs
@@ -49,7 +49,7 @@ impl ProgressStyle {
 
     /// Sets the tick string sequence for spinners.
     pub fn tick_strings(mut self, s: &[&str]) -> ProgressStyle {
-        self.tick_strings = s.iter().map(|s| s.to_string()).collect();
+        self.tick_strings = s.iter().map(|&s| s.to_string()).collect();
         self
     }
 


### PR DESCRIPTION
There is no point to do `&format()` if function do a to_string on the `&str`. `Into<String>` will allow both `&str` and `String` directly so this avoid useless allocation.

Fix some warning too.