### PR TITLE
Implement duration (eta + elapsed) for formatting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,6 +160,9 @@
 //! * `bytes_per_sec`: renders the speed in bytes per second.
 //! * `eta_precise`: the remaining time (like `elapsed_precise`).
 //! * `eta`: the remaining time (like `elapsed`).
+//! * `duration_precise`: the extrapolated total duration (like `elapsed_precise`).
+//! * `duration`: the extrapolated total duration time (like `elapsed`).
+
 //!
 //! The design of the progress bar can be altered with the integrated
 //! template functionality.  The template can be set by changing a

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -315,6 +315,14 @@ impl ProgressState {
         secs_to_duration(t * self.len.saturating_sub(self.pos) as f64 + 0.75)
     }
 
+    /// The expected total duration (that is, elapsed time + expected ETA)
+    pub fn duration(&self) -> Duration {
+        if self.len == !0 || self.is_finished() {
+            return Duration::new(0, 0);
+        }
+        self.started.elapsed() + self.eta()
+    }
+
     /// The number of steps per second
     pub fn per_sec(&self) -> u64 {
         let avg_time = self.avg_time_per_step().as_nanos();

--- a/src/style.rs
+++ b/src/style.rs
@@ -220,6 +220,8 @@ impl ProgressStyle {
                     "bytes_per_sec" => format!("{}/s", HumanBytes(state.per_sec())),
                     "eta_precise" => format!("{}", FormattedDuration(state.eta())),
                     "eta" => format!("{:#}", HumanDuration(state.eta())),
+                    "duration_precise" => format!("{}", FormattedDuration(state.duration())),
+                    "duration" => format!("{:#}", HumanDuration(state.duration())),
                     _ => "".into(),
                 }
             });


### PR DESCRIPTION
This seemed like an obvious, small improvement – tqdm shows the total extrapolated duration, why couldn't indicatif?