### PR TITLE
Add indexed parallel iterator support

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -56,8 +56,10 @@ impl<S, T: Iterator<Item = S>> ProgressIterator for T {
 pub mod rayon_support {
     use super::*;
     use rayon::iter::{
-        plumbing::Consumer, plumbing::Folder, plumbing::UnindexedConsumer, ParallelIterator,
+        plumbing::Consumer, plumbing::Folder, plumbing::UnindexedConsumer, IndexedParallelIterator,
+        ParallelIterator,
     };
+    use std::convert::TryInto;
     use std::sync::{Arc, Mutex};
 
     pub struct ParProgressBarIter<T> {
@@ -84,12 +86,41 @@ pub mod rayon_support {
         }
     }
 
+    pub trait IndexedParallelProgressIterator
+    where
+        Self: Sized,
+    {
+        fn progress_with(self, progress: ProgressBar) -> ParProgressBarIter<Self>;
+
+        fn progress_count(self, len: u64) -> ParProgressBarIter<Self> {
+            self.progress_with(ProgressBar::new(len))
+        }
+
+        fn progress(self) -> ParProgressBarIter<Self> {
+            self.progress_count(0)
+        }
+    }
+
     impl<S: Send, T: ParallelIterator<Item = S>> ParallelProgressIterator for T {
         fn progress_with(self, progress: ProgressBar) -> ParProgressBarIter<Self> {
             ParProgressBarIter {
                 it: self,
                 progress: Arc::new(Mutex::new(progress)),
             }
+        }
+    }
+
+    impl<S: Send, T: IndexedParallelIterator<Item = S>> IndexedParallelProgressIterator for T {
+        fn progress_with(self, progress: ProgressBar) -> ParProgressBarIter<Self> {
+            ParProgressBarIter {
+                it: self,
+                progress: Arc::new(Mutex::new(progress)),
+            }
+        }
+
+        fn progress(self) -> ParProgressBarIter<Self> {
+            let len = self.len().try_into().unwrap();
+            IndexedParallelProgressIterator::progress_count(self, len)
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,4 +198,6 @@ pub use crate::progress::{
 pub use crate::style::ProgressStyle;
 
 #[cfg(feature = "rayon")]
-pub use iter::rayon_support::{ParProgressBarIter, ParallelProgressIterator};
+pub use iter::rayon_support::{
+    IndexedParallelProgressIterator, ParProgressBarIter, ParallelProgressIterator,
+};


### PR DESCRIPTION
Hi,

Rayon exposes a supertrait of `ParallelIterator`, `IndexedParallelIterator`, which has a `len` method. This PR adds a new progress trait, `IndexedParallelProgressIterator`, that wraps `IndexedParallelIterator` and makes the `progress` method work in the same way `ProgressIterator` does with `Iterator`'s `size_hint` method, so we don't have to rely on `progress_count`.

I'm pretty new to working with Rust, and I'm not sure this is the best way of going about this. I tried to add an impl of `ParallelProgressIterator` for `IndexedParallelIterator`, but the compiler complained that the implementations were ambiguous because an `IndexedParallelIterator` is also an `ParallelIterator`. Maybe the extra trait makes this API worse than just getting people to use `progress_count`.