### PR TITLE
Add builder-style functions for initializing prefix, message and position

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -389,6 +389,24 @@ impl ProgressBar {
         self
     }
 
+    /// A convenience builder-like function for a progress bar with a given prefix.
+    pub fn with_prefix(self, prefix: &str) -> ProgressBar {
+        self.state.write().unwrap().prefix = prefix.to_string();
+        self
+    }
+
+    /// A convenience builder-like function for a progress bar with a given message.
+    pub fn with_message(self, message: &str) -> ProgressBar {
+        self.state.write().unwrap().message = message.to_string();
+        self
+    }
+
+    /// A convenience builder-like function for a progress bar with a given position.
+    pub fn with_position(self, pos: u64) -> ProgressBar {
+        self.state.write().unwrap().pos = pos;
+        self
+    }
+
     /// Creates a new spinner.
     ///
     /// This spinner by default draws directly to stderr.  This adds the


### PR DESCRIPTION
In some cases, when creating progress bars that have both a prefix and message (set immediately after creation using set_prefix and set_message), I found that bars were initially being drawn incorrectly due to the refresh frequency limit preventing them from being redrawn after the first set_* call.

In order to allow bars to be fully initialized before being drawn, I have added some additional builder-style functions to allow these values to be set before the bar is drawn.

The following builder-style functions have been added:
* with_prefix
* with_message
* with_position