### PR TITLE
Removed needless clone

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -517,10 +517,10 @@ impl ProgressBar {
     /// Note that if the progress bar is hidden (which by default happens if
     /// the progress bar is redirected into a file) println will not do
     /// anything either.
-    pub fn println<I: Into<String>>(&self, msg: I) {
+    pub fn println<I: AsRef<str>>(&self, msg: I) {
         let mut state = self.state.write().unwrap();
 
-        let mut lines: Vec<String> = msg.into().lines().map(Into::into).collect();
+        let mut lines: Vec<String> = msg.as_ref().lines().map(Into::into).collect();
         let orphan_lines = lines.len();
         if state.should_render() {
             lines.extend(state.style.format_state(&*state));


### PR DESCRIPTION
Closes #213

If behavior like `pb.println(123)` should be allowed, i.e. anything that `impl Display`/`ToString` then merge #213 instead.

However, the behavior of `ToString` would result in:
- 2 needless clones occurring for `pb.println("Foo")` and 
- 1 needless clone for `pb.println(String::from("Foo"))`.

While changing to `AsRef<str>` would:
- Remove 1 existing needless clone occurring when doing `pb.println("Foo")` _(As `msg.into()` needlessly converts it into a `String` which is immediately discarded after `collect()`.)_

> If you call `pb.println(String::from("Hello World"))`, then with `Into<String>` then the `String` is moved. However if you change it to `ToString` then the string is needlessly cloned.
>
> Now, what would be better, would be to change it to `AsRef<str>`. Because `msg.into()` also results in an additional needless clone for `pb.println("Hello World")`, as it gets converted into a `String` which is immediately discarded after `collect()`.
