### PR TITLE
Fix potential loss of force_draw when grouping MultiProgress updates

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1044,6 +1044,7 @@ impl MultiProgress {
         let mut recv_peek = None;
         let mut grouped = 0usize;
         let mut orphan_lines: Vec<String> = Vec::new();
+        let mut force_draw = false;
         while !self.is_done() {
             let (idx, draw_state) = if let Some(peeked) = recv_peek.take() {
                 peeked
@@ -1051,7 +1052,7 @@ impl MultiProgress {
                 self.rx.recv().unwrap()
             };
             let ts = draw_state.ts;
-            let force_draw = draw_state.finished || draw_state.force_draw;
+            force_draw |= draw_state.finished || draw_state.force_draw;
 
             let mut state = self.state.write().unwrap();
             if draw_state.finished {
@@ -1118,6 +1119,8 @@ impl MultiProgress {
                 finished,
                 ts,
             })?;
+
+            force_draw = false;
         }
 
         if clear {


### PR DESCRIPTION
MultiProgress was only passing on the force_draw flag to its draw_target if it
is set on the last ProgressDrawState in a group.

Fix this by handling force_draw similarly to orphan_lines: initialize it outside
the loop, accumulate (set it to true if necessary) as we receive updates, clear
it (set it back to false) after drawing.

I think it is currently not possible to actually hit this bug: the only places
producing a ProgressDrawState with force_draw set are println() and
MultiProgress itself, using println() always forces a draw because orphan_lines
is nonzero, and it looks like it is not currently possible to nest a
MultiProgress in another MultiProgress. I only noticed this because I was making
an unrelated change to this code. But we might as well fix it to avoid future
problems.