### PR TITLE
[RFC] Remove MultiProgress::join()

### DIFF
--- a/examples/finebars.rs
+++ b/examples/finebars.rs
@@ -15,24 +15,29 @@ fn main() {
 
     let m = MultiProgress::new();
 
-    for s in styles.iter() {
-        let pb = m.add(ProgressBar::new(512));
-        pb.set_style(
-            ProgressStyle::default_bar()
-                .template(&format!("{{prefix:.bold}}▕{{bar:.{}}}▏{{msg}}", s.2))
-                .progress_chars(s.1),
-        );
-        pb.set_prefix(s.0);
-        let wait = Duration::from_millis(thread_rng().gen_range(10, 30));
-        thread::spawn(move || {
-            for i in 0..512 {
-                pb.inc(1);
-                pb.set_message(&format!("{:3}%", 100 * i / 512));
-                thread::sleep(wait);
-            }
-            pb.finish_with_message("100%");
-        });
-    }
+    let handles: Vec<_> = styles
+        .iter()
+        .map(|s| {
+            let pb = m.add(ProgressBar::new(512));
+            pb.set_style(
+                ProgressStyle::default_bar()
+                    .template(&format!("{{prefix:.bold}}▕{{bar:.{}}}▏{{msg}}", s.2))
+                    .progress_chars(s.1),
+            );
+            pb.set_prefix(s.0);
+            let wait = Duration::from_millis(thread_rng().gen_range(10, 30));
+            thread::spawn(move || {
+                for i in 0..512 {
+                    pb.inc(1);
+                    pb.set_message(&format!("{:3}%", 100 * i / 512));
+                    thread::sleep(wait);
+                }
+                pb.finish_with_message("100%");
+            })
+        })
+        .collect();
 
-    m.join().unwrap();
+    for h in handles {
+        let _ = h.join();
+    }
 }

--- a/examples/morebars.rs
+++ b/examples/morebars.rs
@@ -27,7 +27,6 @@ fn main() {
             pb.inc(1);
         }
         pb.finish_with_message("done");
-    });
-
-    m.join().unwrap();
+    })
+    .join();
 }

--- a/examples/multi-tree.rs
+++ b/examples/multi-tree.rs
@@ -108,9 +108,8 @@ fn main() {
             }
             thread::sleep(Duration::from_millis(15));
         }
-    });
-
-    mp.join().unwrap();
+    })
+    .join();
 
     println!("===============================");
     println!("the tree should be the same as:");

--- a/examples/multi.rs
+++ b/examples/multi.rs
@@ -11,7 +11,7 @@ fn main() {
 
     let pb = m.add(ProgressBar::new(128));
     pb.set_style(sty.clone());
-    let _ = thread::spawn(move || {
+    let h1 = thread::spawn(move || {
         for i in 0..128 {
             pb.set_message(&format!("item #{}", i + 1));
             pb.inc(1);
@@ -22,7 +22,7 @@ fn main() {
 
     let pb = m.add(ProgressBar::new(128));
     pb.set_style(sty.clone());
-    let _ = thread::spawn(move || {
+    let h2 = thread::spawn(move || {
         for _ in 0..3 {
             pb.set_position(0);
             for i in 0..128 {
@@ -45,5 +45,7 @@ fn main() {
         pb.finish_with_message("done");
     });
 
-    m.join_and_clear().unwrap();
+    let _ = h1.join();
+    let _ = h2.join();
+    m.clear().unwrap();
 }

--- a/examples/yarnish.rs
+++ b/examples/yarnish.rs
@@ -71,24 +71,29 @@ pub fn main() {
         PAPER
     );
     let m = MultiProgress::new();
-    for i in 0..4 {
-        let count = rng.gen_range(30, 80);
-        let pb = m.add(ProgressBar::new(count));
-        pb.set_style(spinner_style.clone());
-        pb.set_prefix(&format!("[{}/?]", i + 1));
-        let _ = thread::spawn(move || {
-            let mut rng = rand::thread_rng();
-            let pkg = PACKAGES.choose(&mut rng).unwrap();
-            for _ in 0..count {
-                let cmd = COMMANDS.choose(&mut rng).unwrap();
-                pb.set_message(&format!("{}: {}", pkg, cmd));
-                pb.inc(1);
-                thread::sleep(Duration::from_millis(rng.gen_range(25, 200)));
-            }
-            pb.finish_with_message("waiting...");
-        });
+    let handles: Vec<_> = (0..4u32)
+        .map(|i| {
+            let count = rng.gen_range(30, 80);
+            let pb = m.add(ProgressBar::new(count));
+            pb.set_style(spinner_style.clone());
+            pb.set_prefix(&format!("[{}/?]", i + 1));
+            thread::spawn(move || {
+                let mut rng = rand::thread_rng();
+                let pkg = PACKAGES.choose(&mut rng).unwrap();
+                for _ in 0..count {
+                    let cmd = COMMANDS.choose(&mut rng).unwrap();
+                    pb.set_message(&format!("{}: {}", pkg, cmd));
+                    pb.inc(1);
+                    thread::sleep(Duration::from_millis(rng.gen_range(25, 200)));
+                }
+                pb.finish_with_message("waiting...");
+            })
+        })
+        .collect();
+    for h in handles {
+        let _ = h.join();
     }
-    m.join_and_clear().unwrap();
+    m.clear().unwrap();
 
     println!("{} Done in {}", SPARKLE, HumanDuration(started.elapsed()));
 }

--- a/tests/multi-autodrop.rs
+++ b/tests/multi-autodrop.rs
@@ -1,20 +1,14 @@
 use indicatif::{MultiProgress, ProgressBar};
-use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
 #[test]
 fn main() {
-    let m = MultiProgress::new();
-    let pb = m.add(ProgressBar::new(10));
-    let (tx, rx) = mpsc::channel();
-
-    // start a thread to drive MultiProgress
-    let h = thread::spawn(move || {
-        m.join().unwrap();
-        tx.send(()).unwrap();
-        println!("Done in thread, droping MultiProgress");
-    });
+    let pb = {
+        let m = MultiProgress::new();
+        m.add(ProgressBar::new(10))
+        // The MultiProgress is dropped here.
+    };
 
     {
         let pb2 = pb.clone();
@@ -24,23 +18,8 @@ fn main() {
         }
     }
 
-    // make sure anything is done in driver thread
-    thread::sleep(Duration::from_millis(50));
-
-    // the driver thread shouldn't finish
-    rx.try_recv()
-        .expect_err("The driver thread shouldn't finish");
-
     pb.set_message("Done");
     pb.finish();
 
-    // make sure anything is done in driver thread
-    thread::sleep(Duration::from_millis(50));
-
-    // the driver thread should finish here
-    rx.try_recv().expect("The driver thread should finish");
-
-    h.join().unwrap();
-
-    println!("Done in main");
+    println!("Done with MultiProgress");
 }


### PR DESCRIPTION
This should not be merged yet, but I'd like to know if this looks like something worth pursuing.

This change moves drawing of MultiProgress from the join() thread to the child ProgressBar updates.

This has the following advantages:

- It addresses #125 (async MultiProgress), as long as users are willing to assume the writes to the screen do not block (and they do not add enough child progress bars for lock contention on the MultiProgress state to be an issue). It also makes it trivial to use MultiProgress without any threads or async runtime at all.
- It helps with #205 (add println to MultiProgress) because println on MultiProgress can now be made to work while the MultiProgress does not have any unfinished progress bars / join() hasn't been called yet.
- Arguably the code is simpler (and it removes the one use of `unsafe` in indicatif: MultiProgress is now automatically `Sync`).

It also has disadvantages, most of which I think can be mitigated:

- It removes grouping, which regresses the problem fixed by #166. I think it is possible to largely mitigate this by implementing a draw target that uses a timer (via an async runtime or a thread) to schedule a draw `rate - last_draw.elapsed()` in the future if we don't want to draw immediately. I haven't written the code for this yet, though, so it might not be as easy as I think...
- It is backwards-incompatible. This could be mitigated by implementing this as a new type (and a new `ProgressDrawTargetKind`, which is fine as those are not public) if the old behavior is deemed useful enough to keep around and/or we want to avoid the semver bump.
- It removes the ability to use the MultiProgress as a synchronization point. For the examples, this was very easy to fix by joining the worker threads instead. I don't know if this is also true for "real" code.
- It moves work from the join() thread to the threads updating the progress bars. I suspect this is not a problem because that work is already fast enough (relative to rendering the child progress bar to a ProgressDrawState, which was already happening on the worker threads), but I haven't benchmarked it. It might be a problem for code that has at least one progress bar that is updated at a very high rate.

I think the DrawTarget-with-a-timer is useful anyway: it should mitigate a problem very similar to #166 when doing something like:
```rust
use std::thread;
use std::time::Duration;

use indicatif::ProgressBar;

fn main() {
    let p = ProgressBar::new_spinner();
    for _ in 0..10 {
        p.set_message("performing fast work (you should rarely see this)");
        // Just to demonstrate they don't need to be back-to-back. Removing this sleep does not change behavior.
        thread::sleep(Duration::from_millis(5));
        p.set_message("performing slow work (you should see this)");
        thread::sleep(Duration::from_secs(1));
    }
}
```
This currently only shows "you should not see this" for the same reason the MultiProgress example didn't stay in sync. With a DrawTarget-with-a-timer, it would show "you should not see this" for only one update interval. So I'll probably see if I can get that to work even if this change isn't deemed useful.

Please let me know what you think!