### PR TITLE
BufRead for ProgressBarWrap

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1268,6 +1268,17 @@ impl<R: io::Read> io::Read for ProgressBarWrap<R> {
     }
 }
 
+impl<R: io::BufRead> io::BufRead for ProgressBarWrap<R> {
+    fn fill_buf(&mut self) -> io::Result<&[u8]> {
+        self.wrap.fill_buf()
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.wrap.consume(amt);
+        self.bar.inc(amt as u64);
+    }
+}
+
 impl<S: io::Seek> io::Seek for ProgressBarWrap<S> {
     fn seek(&mut self, f: io::SeekFrom) -> io::Result<u64> {
         self.wrap.seek(f).map(|pos| {


### PR DESCRIPTION
Required in order to use `wrap_read` together with flate2's `GzDecoder` or any other decoder built on `BufRead`.

```rust
use flate2::bufread::GzDecoder; // flate2 = "1.0"
use indicatif::ProgressBar;
use std::fs::File;
use std::io::BufReader;
use tar::Archive; // tar = "0.4"

fn main() {
    let file = File::open("...").unwrap();
    let len = file.metadata().unwrap().len();
    let buf = BufReader::new(file);
    let pb = ProgressBar::new(len);
    let input = pb.wrap_read(buf);
    let archive = Archive::new(GzDecoder::new(input));
    // ...
}
```

Before:

```console
error[E0277]: the trait bound `ProgressBarWrap<BufReader<std::fs::File>>: BufRead` is not satisfied
  --> src/main.rs:13:47
   |
13 |     let archive = Archive::new(GzDecoder::new(input));
   |                                               ^^^^^ the trait `BufRead` is not implemented for `ProgressBarWrap<BufReader<std::fs::File>>`
   |
   = note: required by `flate2::bufread::GzDecoder::<R>::new`
```

After: works.