### PR TITLE
Add ProgressFinish API

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -50,8 +50,8 @@ impl<S, T: Iterator<Item = S>> Iterator for ProgressBarIter<T> {
 
         if item.is_some() {
             self.progress.inc(1);
-        } else {
-            self.progress.finish();
+        } else if !self.progress.is_finished() {
+            self.progress.finish_using_style();
         }
 
         item
@@ -70,8 +70,8 @@ impl<T: DoubleEndedIterator> DoubleEndedIterator for ProgressBarIter<T> {
 
         if item.is_some() {
             self.progress.inc(1);
-        } else {
-            self.progress.finish();
+        } else if !self.progress.is_finished() {
+            self.progress.finish_using_style();
         }
 
         item

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,7 +215,7 @@ mod utils;
 pub use crate::format::{BinaryBytes, DecimalBytes, FormattedDuration, HumanBytes, HumanDuration};
 pub use crate::iter::{ProgressBarIter, ProgressIterator};
 pub use crate::progress::{MultiProgress, ProgressBar, ProgressDrawTarget, WeakProgressBar};
-pub use crate::style::ProgressStyle;
+pub use crate::style::{ProgressFinish, ProgressStyle};
 
 #[cfg(feature = "rayon")]
 pub use crate::rayon::ParallelProgressIterator;

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Mutex, RwLock, Weak};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use crate::style::ProgressStyle;
+use crate::style::{ProgressFinish, ProgressStyle};
 use crate::utils::{duration_to_secs, secs_to_duration, Estimate};
 use crate::{ProgressBarIter, ProgressIterator};
 use console::Term;
@@ -822,6 +822,33 @@ impl ProgressBar {
     /// must be present in the template (see `ProgressStyle`).
     pub fn abandon_with_message(&self, msg: &str) {
         self.state.lock().unwrap().abandon_with_message(msg);
+    }
+
+    /// Finishes the progress bar using the [`ProgressFinish`] behavior stored
+    /// in the [`ProgressStyle`].
+    pub fn finish_using_style(&self) {
+        let on_finish = self.state.lock().unwrap().style.get_on_finish().clone();
+        match on_finish {
+            ProgressFinish::Default => {
+                self.finish();
+            }
+            ProgressFinish::AtCurrentPos => {
+                self.finish_at_current_pos();
+            }
+            ProgressFinish::WithMessage(msg) => {
+                self.finish_with_message(&msg);
+            }
+            ProgressFinish::AndClear => {
+                self.finish_and_clear();
+            }
+            ProgressFinish::Abandon => {
+                self.abandon();
+            }
+            ProgressFinish::AbandonWithMessage(msg) => {
+                self.abandon_with_message(&msg);
+            }
+            ProgressFinish::None => { /* do nothing */ }
+        }
     }
 
     /// Sets a different draw target for the progress bar.

--- a/src/rayon.rs
+++ b/src/rayon.rs
@@ -180,6 +180,9 @@ impl<T, C: Folder<T>> Folder<T> for ProgressFolder<C> {
     }
 
     fn complete(self) -> C::Result {
+        if !self.progress.is_finished() {
+            self.progress.finish_using_style();
+        }
         self.base.complete()
     }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -31,8 +31,6 @@ pub enum ProgressFinish {
     /// Finishes the progress bar and sets a message, and leaves the current progress.
     /// Same behavior as calling [`ProgressBar::abandon_with_message()`].
     AbandonWithMessage(Cow<'static, str>),
-    /// Do nothing.  Leave the progres bar unfinished.
-    None,
 }
 
 impl Default for ProgressFinish {
@@ -47,7 +45,7 @@ pub struct ProgressStyle {
     tick_strings: Vec<Box<str>>,
     progress_chars: Vec<Box<str>>,
     template: Box<str>,
-    pub(super) on_finish: ProgressFinish,
+    pub(super) on_finish: Option<ProgressFinish>,
     // how unicode-big each char in progress_chars is
     char_width: usize,
 }
@@ -102,7 +100,7 @@ impl ProgressStyle {
             progress_chars,
             char_width,
             template: "{wide_bar} {pos}/{len}".into(),
-            on_finish: ProgressFinish::default(),
+            on_finish: Some(ProgressFinish::default()),
         }
     }
 
@@ -118,7 +116,7 @@ impl ProgressStyle {
             progress_chars,
             char_width,
             template: "{spinner} {msg}".into(),
-            on_finish: ProgressFinish::default(),
+            on_finish: Some(ProgressFinish::default()),
         }
     }
 
@@ -173,7 +171,9 @@ impl ProgressStyle {
     /// This behavior is invoked when [`ProgressBar`] or
     /// [`ProgresBarIter`](crate::ProgressBarIter) completes and
     /// [`ProgressBar::is_finished()`] is false.
-    pub fn on_finish(mut self, f: ProgressFinish) -> ProgressStyle {
+    /// If you don't want the progress bar to be automatically finished then
+    /// call `on_finish(None)`.
+    pub fn on_finish(mut self, f: Option<ProgressFinish>) -> ProgressStyle {
         self.on_finish = f;
         self
     }
@@ -201,7 +201,7 @@ impl ProgressStyle {
     }
 
     /// Returns the finish behavior.
-    pub fn get_on_finish(&self) -> &ProgressFinish {
+    pub fn get_on_finish(&self) -> &Option<ProgressFinish> {
         &self.on_finish
     }
 


### PR DESCRIPTION
As discussed in a [tangentially related PR](https://github.com/mitsuhiko/indicatif/pull/240), it would be nice to have an API for specifying how a progress bar should be `finish()`ed by default when it is dropped or when an iterator it is wrapping has finished.  This PR proposes such an API by adding a `ProgressFinish` enum to the `ProgressStyle`, which can be used like this:

```rust
let pb = ProgressBar::new().with_style(
    ProgressStyle::default_bar().on_finish(ProgressFinish::AndClear)
);
```

In this example `pb` will automatically have `finish_and_clear()` called on it when it is dropped, unless the user manually calls one of the other `finish()` methods before dropping.

This is especially useful for set-it and forget-it style progress bars used in iterators.  For example:

```rust
const DELAY: Duration = Duration::from_millis(100);
(0..10).progress_with(pb).for_each(|_| sleep(DELAY));
// Don't have to clone pb and call finish_and_clear()
```

Unfortunately I am not familiar with Rayon-style parallel iterators and so have ***not*** attempted to modify the Rayon parallel iterator API to use the new API (I am not even sure if this is possible).  I also have ***not*** attempted to modify `ProgressBarWrap` to automatically finish its progress bar since the `std::io::Read` and `Write` APIs do not provide any unambiguous way to know whether the underlying reader or writer is "finished."

---

Under the hood, this PR:

1. Adds an enum `ProgressFinish` whose variants correspond to the methods `finish()`, `finish_and_clear()`, etc.
2. Adds a field `ProgressStyle::on_finish` to store the desired `ProgressFinish` behavior.
3. Adds `ProgressState::update_and_draw()` and moves most of the logic from `ProgressBar::update_and_draw()` there.
4. Adds `ProgressState::finish()` and related methods, and makes the `ProgressBar::finish()` methods delegate to them.
5. Modifies the `Drop` trait for `ProgressState` to use the behavior specified by the `ProgressStyle::on_finish`.
6. Modifies the `Iterator` implementation for `ProgressBarIter` to use the `ProgressStyle::on_finish` behavior when the iterator completes (i.e. yields `None`).
7. Also adds a `Drop` trait to `ProgressBarIter` which makes sure the bar gets finished even if the iterator doesn't complete.