### PR TITLE
Remove ProgressState::width

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -154,10 +154,7 @@ impl ProgressDrawTarget {
         match self.kind {
             ProgressDrawTargetKind::Term { ref term, .. } => term.size().1 as usize,
             ProgressDrawTargetKind::Remote { ref state, .. } => state.read().unwrap().width(),
-            ProgressDrawTargetKind::Hidden => {
-                // TODO: Expose `console::term::DEFAULT_WIDTH`?
-                79
-            }
+            ProgressDrawTargetKind::Hidden => 0,
         }
     }
 

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -254,7 +254,6 @@ pub(crate) struct ProgressState {
     pub(crate) tick: u64,
     pub(crate) started: Instant,
     draw_target: ProgressDrawTarget,
-    width: Option<u16>,
     message: String,
     prefix: String,
     draw_delta: u64,
@@ -319,11 +318,7 @@ impl ProgressState {
 
     /// The entire draw width
     pub fn width(&self) -> usize {
-        if let Some(width) = self.width {
-            width as usize
-        } else {
-            self.draw_target.width()
-        }
+        self.draw_target.width()
     }
 
     /// Return the current average time per step
@@ -400,7 +395,6 @@ impl ProgressBar {
             state: Arc::new(RwLock::new(ProgressState {
                 style: ProgressStyle::default_bar(),
                 draw_target: target,
-                width: None,
                 message: "".into(),
                 prefix: "".into(),
                 pos: 0,

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -154,7 +154,7 @@ impl ProgressDrawTarget {
         match self.kind {
             ProgressDrawTargetKind::Term { ref term, .. } => term.size().1 as usize,
             ProgressDrawTargetKind::Remote { ref state, .. } => state.read().unwrap().width(),
-            ProgressDrawTargetKind::Hidden => 0,
+            ProgressDrawTargetKind::Hidden => unreachable!(),
         }
     }
 
@@ -592,7 +592,7 @@ impl ProgressBar {
 
         let mut lines: Vec<String> = msg.as_ref().lines().map(Into::into).collect();
         let orphan_lines = lines.len();
-        if state.should_render() {
+        if state.should_render() && !state.draw_target.is_hidden() {
             lines.extend(state.style.format_state(&*state));
         }
 


### PR DESCRIPTION
This variable was always `None` and used in only one place. It was
probably created to cache the target's width, however it's not too
expensive to check and can create problems after resizing a terminal (a
`wide_xyz` placeholder will use wrong width)