### PR TITLE
Add back clone required to trigger a bug

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1333,7 +1333,10 @@ mod tests {
     fn late_pb_drop() {
         let pb = ProgressBar::new(10);
         let mpb = MultiProgress::new();
-        mpb.add(pb);
+        // This clone call is required to trigger a now fixed bug.
+        // See <https://github.com/mitsuhiko/indicatif/pull/141> for context
+        #[allow(clippy::redundant_clone)]
+        mpb.add(pb.clone());
     }
 
     #[test]


### PR DESCRIPTION
This clone call is actually necessary. Without it a now-fixed bug will not be triggered. To test this change `ProgressDrawTarget::apply_draw_state` (line 165) from:
```rust
ProgressDrawTargetKind::Remote { idx, ref chan, .. } => {
    return chan
        .lock()
        .unwrap()
        .send((idx, draw_state))
        .map_err(|e| io::Error::new(io::ErrorKind::Other, e));
}
```
to:
```rust
ProgressDrawTargetKind::Remote { idx, ref chan, .. } => {
    chan
        .lock()
        .unwrap()
        .send((idx, draw_state))
        .map_err(|e| io::Error::new(io::ErrorKind::Other, e)).unwrap();
}
```