### PR TITLE
Change ProgressStyle::template from Cow<'static, str> to Box<str>

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use console::{measure_text_width, Style};
 
 use crate::format::{BinaryBytes, DecimalBytes, FormattedDuration, HumanBytes, HumanDuration};
@@ -14,7 +12,7 @@ use unicode_segmentation::UnicodeSegmentation;
 pub struct ProgressStyle {
     tick_strings: Vec<Box<str>>,
     progress_chars: Vec<Box<str>>,
-    template: Cow<'static, str>,
+    template: Box<str>,
     // how unicode-big each char in progress_chars is
     char_width: usize,
 }
@@ -68,7 +66,7 @@ impl ProgressStyle {
                 .collect(),
             progress_chars,
             char_width,
-            template: Cow::Borrowed("{wide_bar} {pos}/{len}"),
+            template: "{wide_bar} {pos}/{len}".into(),
         }
     }
 
@@ -83,7 +81,7 @@ impl ProgressStyle {
                 .collect(),
             progress_chars,
             char_width,
-            template: Cow::Borrowed("{spinner} {msg}"),
+            template: "{spinner} {msg}".into(),
         }
     }
 
@@ -112,7 +110,7 @@ impl ProgressStyle {
     ///
     /// List of keys is available at crate root docs.
     pub fn template(mut self, s: &str) -> ProgressStyle {
-        self.template = Cow::Owned(s.into());
+        self.template = s.into();
         self
     }
 


### PR DESCRIPTION
This reduces ProgressStyle's size by 16 bytes.

Cow is useful when occasionally mutating the data inside, however
it was never mutated, and only read from. The only, negligible, benefit
is when reusing a single static str as a template across multiple
progress bars (as the template would be stored in memory only once;
as an example the template in download-continued is 106 bytes),
however the current API doesn't even expose such a functionality despite
it being easily implementable.