### PR TITLE
Unify Estimate behavior

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -689,7 +689,7 @@ impl ProgressBar {
     /// paused for a prolonged time.
     pub fn reset_eta(&self) {
         self.update_and_draw(|state| {
-            state.est.reset();
+            state.est.reset(state.pos);
         });
     }
 


### PR DESCRIPTION
Up until now Estimate would be in a fully initialized state after
calling `new`, however after calling `reset` it would get fully
initialized only on the next call to `record_step`. This is an
unexpected disparity that this commit unifies. Now, when calling `reset`
 you must also provide a `start_value`, so that the Estimate can not be
 in a semi-initialized state anymore.