### PR TITLE
Fix HumanBytes display

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -78,12 +78,7 @@ impl fmt::Display for HumanBytes {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match NumberPrefix::binary(self.0 as f64) {
             NumberPrefix::Standalone(number) => write!(f, "{:.0}B", number),
-            NumberPrefix::Prefixed(prefix, number) => write!(
-                f,
-                "{:.2}{}B",
-                number,
-                prefix.upper().chars().next().unwrap()
-            ),
+            NumberPrefix::Prefixed(prefix, number) => write!(f, "{:.2}{}B", number, prefix),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,7 @@
 //! # use std::time::Duration;
 //! use indicatif::{HumanDuration, HumanBytes};
 //!
-//! assert_eq!("3.00MB", HumanBytes(3*1024*1024).to_string());
+//! assert_eq!("3.00MiB", HumanBytes(3*1024*1024).to_string());
 //! assert_eq!("8 seconds", HumanDuration(Duration::from_secs(8)).to_string());
 //! ```
 //!


### PR DESCRIPTION
HumanBytes displays wrong binary prefix. For example, 1024 bytes should be "1KiB" but not "1KB".