### PR TITLE
Unwrap ProgressFinish

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -208,7 +208,7 @@ impl ProgressState {
     /// in the [`ProgressStyle`].
     pub fn finish_using_style(&mut self) {
         match self.style.get_on_finish() {
-            ProgressFinish::Finish => self.finish(),
+            ProgressFinish::AndLeave => self.finish(),
             ProgressFinish::AtCurrentPos => self.finish_at_current_pos(),
             ProgressFinish::WithMessage(msg) => {
                 // Equivalent to `self.finish_with_message` but avoids borrow checker error

--- a/src/state.rs
+++ b/src/state.rs
@@ -208,7 +208,7 @@ impl ProgressState {
     /// in the [`ProgressStyle`].
     pub fn finish_using_style(&mut self) {
         match self.style.get_on_finish() {
-            ProgressFinish::Default => self.finish(),
+            ProgressFinish::Finish => self.finish(),
             ProgressFinish::AtCurrentPos => self.finish_at_current_pos(),
             ProgressFinish::WithMessage(msg) => {
                 // Equivalent to `self.finish_with_message` but avoids borrow checker error

--- a/src/state.rs
+++ b/src/state.rs
@@ -207,29 +207,20 @@ impl ProgressState {
     /// Finishes the progress bar using the [`ProgressFinish`] behavior stored
     /// in the [`ProgressStyle`].
     pub fn finish_using_style(&mut self) {
-        let on_finish = match self.style.on_finish.take() {
-            Some(on_finish) => on_finish,
-            None => return,
-        };
-
-        match on_finish {
-            ProgressFinish::Default => {
+        match self.style.get_on_finish() {
+            ProgressFinish::Default => self.finish(),
+            ProgressFinish::AtCurrentPos => self.finish_at_current_pos(),
+            ProgressFinish::WithMessage(msg) => {
+                // Equivalent to `self.finish_with_message` but avoids borrow checker error
+                self.message.clone_from(msg);
                 self.finish();
             }
-            ProgressFinish::AtCurrentPos => {
-                self.finish_at_current_pos();
-            }
-            ProgressFinish::WithMessage(msg) => {
-                self.finish_with_message(msg);
-            }
-            ProgressFinish::AndClear => {
-                self.finish_and_clear();
-            }
-            ProgressFinish::Abandon => {
-                self.abandon();
-            }
+            ProgressFinish::AndClear => self.finish_and_clear(),
+            ProgressFinish::Abandon => self.abandon(),
             ProgressFinish::AbandonWithMessage(msg) => {
-                self.abandon_with_message(msg);
+                // Equivalent to `self.abandon_with_message` but avoids borrow checker error
+                self.message.clone_from(msg);
+                self.abandon();
             }
         }
     }
@@ -262,15 +253,7 @@ impl Drop for ProgressState {
             return;
         }
 
-        // How should we finish the bar?
-        match self.style.on_finish {
-            Some(_) => self.finish_using_style(),
-            None => {
-                // Fallback to original drop behavior for bars that are not finished.
-                self.status = Status::DoneHidden;
-                self.draw().ok();
-            }
-        }
+        self.finish_using_style();
     }
 }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -45,7 +45,7 @@ pub struct ProgressStyle {
     tick_strings: Vec<Box<str>>,
     progress_chars: Vec<Box<str>>,
     template: Box<str>,
-    pub(super) on_finish: Option<ProgressFinish>,
+    on_finish: ProgressFinish,
     // how unicode-big each char in progress_chars is
     char_width: usize,
 }
@@ -100,7 +100,7 @@ impl ProgressStyle {
             progress_chars,
             char_width,
             template: "{wide_bar} {pos}/{len}".into(),
-            on_finish: Some(ProgressFinish::default()),
+            on_finish: ProgressFinish::default(),
         }
     }
 
@@ -116,7 +116,7 @@ impl ProgressStyle {
             progress_chars,
             char_width,
             template: "{spinner} {msg}".into(),
-            on_finish: Some(ProgressFinish::default()),
+            on_finish: ProgressFinish::default(),
         }
     }
 
@@ -173,8 +173,8 @@ impl ProgressStyle {
     /// [`ProgressBar::is_finished()`] is false.
     /// If you don't want the progress bar to be automatically finished then
     /// call `on_finish(None)`.
-    pub fn on_finish(mut self, f: Option<ProgressFinish>) -> ProgressStyle {
-        self.on_finish = f;
+    pub fn on_finish(mut self, finish: ProgressFinish) -> ProgressStyle {
+        self.on_finish = finish;
         self
     }
 
@@ -201,7 +201,7 @@ impl ProgressStyle {
     }
 
     /// Returns the finish behavior.
-    pub fn get_on_finish(&self) -> &Option<ProgressFinish> {
+    pub fn get_on_finish(&self) -> &ProgressFinish {
         &self.on_finish
     }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -15,7 +15,7 @@ use unicode_segmentation::UnicodeSegmentation;
 pub enum ProgressFinish {
     /// Finishes the progress bar and leaves the current message.
     /// Same behavior as calling [`ProgressBar::finish()`].
-    Finish,
+    AndLeave,
     /// Finishes the progress bar at current position and leaves the current message.
     /// Same behavior as calling [`ProgressBar::finish_at_current_pos()`].
     AtCurrentPos,

--- a/src/style.rs
+++ b/src/style.rs
@@ -15,14 +15,14 @@ use unicode_segmentation::UnicodeSegmentation;
 pub enum ProgressFinish {
     /// Finishes the progress bar and leaves the current message.
     /// Same behavior as calling [`ProgressBar::finish()`].
-    Default,
+    Finish,
     /// Finishes the progress bar at current position and leaves the current message.
     /// Same behavior as calling [`ProgressBar::finish_at_current_pos()`].
     AtCurrentPos,
     /// Finishes the progress bar and sets a message.
     /// Same behavior as calling [`ProgressBar::finish_with_message()`].
     WithMessage(Cow<'static, str>),
-    /// Finishes the progress bar and completely clears it.
+    /// Finishes the progress bar and completely clears it. This is the default behavior.
     /// Same behavior as calling [`ProgressBar::finish_and_clear()`].
     AndClear,
     /// Finishes the progress bar and leaves the current message and progress.
@@ -35,7 +35,7 @@ pub enum ProgressFinish {
 
 impl Default for ProgressFinish {
     fn default() -> Self {
-        Self::Default
+        Self::AndClear
     }
 }
 


### PR DESCRIPTION
This changes default behavior - now a progress bar without an explicitly set on_finish will call `finish`, when previously it would call `finish_and_clear` ([`src/style.rs:103`](https://github.com/mitsuhiko/indicatif/compare/main...mibac138:on-finish?expand=1#diff-5452dc5fb15e73154c0ecc33e87a14379a97f817fe0cdb0fb9d17df712feb8fbR103)). Also, `on_finish` won't be reset every time `finish_with_style` is called.