### PR TITLE
Have cargo example more closely match cargo

### DIFF
--- a/examples/cargo.rs
+++ b/examples/cargo.rs
@@ -1,43 +1,43 @@
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use console::Term;
-use indicatif::{ProgressBar, ProgressStyle};
+use console::{Style, Term};
+use indicatif::{HumanDuration, ProgressBar, ProgressStyle};
 use rand::Rng;
 
-static CRATES: &[&str] = &[
-    "console",
-    "lazy_static",
-    "libc",
-    "regex",
-    "regex-syntax",
-    "terminal_size",
-    "libc",
-    "unicode-width",
-    "lazy_static",
-    "number_prefix",
-    "regex",
-    "rand",
-    "getrandom",
-    "cfg-if",
-    "libc",
-    "rand_chacha",
-    "ppv-lite86",
-    "rand_core",
-    "getrandom",
-    "rand_core",
-    "tokio",
-    "bytes",
-    "pin-project-lite",
-    "slab",
-    "indicatif",
-    "cargo(example)",
+static CRATES: &[(&str, &str)] = &[
+    ("console", "v0.14.1"),
+    ("lazy_static", "v1.4.0"),
+    ("libc", "v0.2.93"),
+    ("regex", "v1.4.6"),
+    ("regex-syntax", "v0.6.23"),
+    ("terminal_size", "v0.1.16"),
+    ("libc", "v0.2.93"),
+    ("unicode-width", "v0.1.8"),
+    ("lazy_static", "v1.4.0"),
+    ("number_prefix", "v0.4.0"),
+    ("regex", "v1.4.6"),
+    ("rand", "v0.8.3"),
+    ("getrandom", "v0.2.2"),
+    ("cfg-if", "v1.0.0"),
+    ("libc", "v0.2.93"),
+    ("rand_chacha", "v0.3.0"),
+    ("ppv-lite86", "v0.2.10"),
+    ("rand_core", "v0.6.2"),
+    ("getrandom", "v0.2.2"),
+    ("rand_core", "v0.6.2"),
+    ("tokio", "v1.5.0"),
+    ("bytes", "v1.0.1"),
+    ("pin-project-lite", "v0.2.6"),
+    ("slab", "v0.4.3"),
+    ("indicatif", "v0.15.0"),
 ];
 
 fn main() {
-    // number of cpus, constant
-    let cpus = 4;
+    // number of cpus
+    const NUM_CPUS: usize = 4;
+    let start = Instant::now();
 
     // mimic cargo progress bar although it behaves a bit different
     let pb = ProgressBar::new(CRATES.len() as u64);
@@ -46,11 +46,11 @@ fn main() {
             // note that bar size is fixed unlike cargo which is dynamic
             // and also the truncation in cargo uses trailers (`...`)
             .template(if Term::stdout().size().1 > 80 {
-                "{prefix:>12.green} [{bar:57}] {pos}/{len} {wide_msg}"
+                "{prefix:>12.cyan.bold} [{bar:57}] {pos}/{len} {wide_msg}"
             } else {
-                "{prefix:>12.green} [{bar:57}] {pos}/{len}"
+                "{prefix:>12.cyan.bold} [{bar:57}] {pos}/{len}"
             })
-            .progress_chars("#> "),
+            .progress_chars("=> "),
     );
     pb.set_prefix("Building");
 
@@ -58,7 +58,7 @@ fn main() {
     // crates to be iterated but not exactly a tree
     let crates = Arc::new(Mutex::new(CRATES.iter()));
     let (tx, rx) = mpsc::channel();
-    for n in 0..cpus {
+    for n in 0..NUM_CPUS {
         let tx = tx.clone();
         let crates = crates.clone();
         thread::spawn(move || {
@@ -70,10 +70,10 @@ fn main() {
                 if let Some(krate) = krate {
                     thread::sleep(Duration::from_millis(
                         // last compile and linking is always slow, let's mimic that
-                        if CRATES[CRATES.len() - 1] == *krate {
-                            rng.gen_range(1000..2000)
+                        if CRATES.last() == Some(krate) {
+                            rng.gen_range(1_000..2_000)
                         } else {
-                            rng.gen_range(50..300)
+                            rng.gen_range(250..1_000)
                         },
                     ));
                 } else {
@@ -85,16 +85,36 @@ fn main() {
     // drop tx to stop waiting
     drop(tx);
 
+    let green_bold = Style::new().green().bold();
+
     // do progress drawing in main thread
-    let mut processing = vec![None; cpus];
+    let mut processing = vec![None; NUM_CPUS];
     while let Ok((n, krate)) = rx.recv() {
         processing[n] = krate;
-        let crates: Vec<&str> = processing.iter().filter_map(|t| t.copied()).collect();
+        let crates: Vec<&str> = processing
+            .iter()
+            .filter_map(|t| t.copied().map(|(name, _)| name))
+            .collect();
         pb.set_message(crates.join(", "));
-        if krate.is_some() {
-            // crate is built
+        if let Some((name, version)) = krate {
+            // crate is being built
+            let line = format!(
+                "{:>12} {} {}",
+                green_bold.apply_to("Compiling"),
+                name,
+                version
+            );
+            pb.println(line);
+
             pb.inc(1);
         }
     }
     pb.finish_and_clear();
+
+    // compilation is finished
+    println!(
+        "{:>12} dev [unoptimized + debuginfo] target(s) in {}",
+        green_bold.apply_to("Finished"),
+        HumanDuration(start.elapsed())
+    );
 }


### PR DESCRIPTION
Hello thanks for the great crate! I loved all the examples and just wanted to improve on the `cargo` example a bit. Just a quick overview of the changes:

- Bumped up the time to "build" each crate so it's easier to follow what's happening
- Added a `Compiling ...` line for each crate
    - This did involve storing a dummy version as well
- Added a `Finished ...` line to better match `cargo`

### Old example

![old_cargo_example](https://user-images.githubusercontent.com/30302768/115950148-86068500-a4a7-11eb-81bd-48b26471d218.gif)

### New example

![new_cargo_example](https://user-images.githubusercontent.com/30302768/115950152-8dc62980-a4a7-11eb-931a-3226060f4089.gif)