### PR TITLE
Make "unicode-width" dependency actually optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["screenshots/*"]
 regex = { version = "1.3.1", default-features = false, features = ["std"] }
 lazy_static = "1.0"
 number_prefix = "0.4"
-console = ">=0.9.1, <1.0.0"
+console = { version = ">=0.9.1, <1.0.0", default-features = false }
 unicode-segmentation = { version = "1.6.0", optional = true }
 unicode-width = { version = "0.1.7", optional = true }
 rayon = { version = "1.0", optional = true }


### PR DESCRIPTION
Fixes #280

This also disables the `ansi-parsing` feature in `console`, I don't know if that breaks anything or not.