### PR TITLE
Remove MultiProgress::join() based on #231

### DIFF
--- a/examples/morebars.rs
+++ b/examples/morebars.rs
@@ -11,23 +11,18 @@ fn main() {
     let pb = m.add(ProgressBar::new(5));
     pb.set_style(sty.clone());
 
-    let m2 = m.clone();
-    let _ = thread::spawn(move || {
-        // make sure we show up at all.  otherwise no rendering
-        // event.
-        pb.tick();
-        for _ in 0..5 {
-            let pb2 = m2.add(ProgressBar::new(128));
-            pb2.set_style(sty.clone());
-            for _ in 0..128 {
-                pb2.inc(1);
-                thread::sleep(Duration::from_millis(5));
-            }
-            pb2.finish();
-            pb.inc(1);
+    // make sure we show up at all.  otherwise no rendering
+    // event.
+    pb.tick();
+    for _ in 0..5 {
+        let pb2 = m.add(ProgressBar::new(128));
+        pb2.set_style(sty.clone());
+        for _ in 0..128 {
+            pb2.inc(1);
+            thread::sleep(Duration::from_millis(5));
         }
-        pb.finish_with_message("done");
-    });
-
-    m.join().unwrap();
+        pb2.finish();
+        pb.inc(1);
+    }
+    pb.finish_with_message("done");
 }

--- a/examples/multi-tree.rs
+++ b/examples/multi-tree.rs
@@ -135,9 +135,8 @@ fn main() {
             }
             thread::sleep(Duration::from_millis(15));
         }
-    });
-
-    mp.join().unwrap();
+    })
+    .join();
 
     println!("===============================");
     println!("the tree should be the same as:");

--- a/examples/multi.rs
+++ b/examples/multi.rs
@@ -11,7 +11,7 @@ fn main() {
 
     let pb = m.add(ProgressBar::new(128));
     pb.set_style(sty.clone());
-    let _ = thread::spawn(move || {
+    let h1 = thread::spawn(move || {
         for i in 0..128 {
             pb.set_message(format!("item #{}", i + 1));
             pb.inc(1);
@@ -22,7 +22,7 @@ fn main() {
 
     let pb = m.add(ProgressBar::new(128));
     pb.set_style(sty.clone());
-    let _ = thread::spawn(move || {
+    let h2 = thread::spawn(move || {
         for _ in 0..3 {
             pb.set_position(0);
             for i in 0..128 {
@@ -45,5 +45,7 @@ fn main() {
         pb.finish_with_message("done");
     });
 
-    m.join_and_clear().unwrap();
+    let _ = h1.join();
+    let _ = h2.join();
+    m.clear().unwrap();
 }

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -757,17 +757,24 @@ impl MultiProgress {
         }
 
         if clear {
-            let mut state = self.state.write().unwrap();
-            state.draw_target.apply_draw_state(ProgressDrawState {
-                lines: vec![],
-                orphan_lines: 0,
-                finished: true,
-                force_draw: true,
-                move_cursor,
-            })?;
+            self.clear()?;
         }
 
         self.joining.store(false, Ordering::Release);
+
+        Ok(())
+    }
+
+    pub fn clear(&self) -> io::Result<()> {
+        let mut state = self.state.write().unwrap();
+        let move_cursor = state.move_cursor;
+        state.draw_target.apply_draw_state(ProgressDrawState {
+            lines: vec![],
+            orphan_lines: 0,
+            finished: true,
+            force_draw: true,
+            move_cursor,
+        })?;
 
         Ok(())
     }

--- a/tests/multi-autodrop.rs
+++ b/tests/multi-autodrop.rs
@@ -1,20 +1,14 @@
 use indicatif::{MultiProgress, ProgressBar};
-use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
 #[test]
 fn main() {
-    let m = MultiProgress::new();
-    let pb = m.add(ProgressBar::new(10));
-    let (tx, rx) = mpsc::channel();
-
-    // start a thread to drive MultiProgress
-    let h = thread::spawn(move || {
-        m.join().unwrap();
-        tx.send(()).unwrap();
-        println!("Done in thread, droping MultiProgress");
-    });
+    let pb = {
+        let m = MultiProgress::new();
+        m.add(ProgressBar::new(10))
+        // The MultiProgress is dropped here.
+    };
 
     {
         let pb2 = pb.clone();
@@ -24,23 +18,8 @@ fn main() {
         }
     }
 
-    // make sure anything is done in driver thread
-    thread::sleep(Duration::from_millis(50));
-
-    // the driver thread shouldn't finish
-    rx.try_recv()
-        .expect_err("The driver thread shouldn't finish");
-
     pb.set_message("Done");
     pb.finish();
 
-    // make sure anything is done in driver thread
-    thread::sleep(Duration::from_millis(50));
-
-    // the driver thread should finish here
-    rx.try_recv().expect("The driver thread should finish");
-
-    h.join().unwrap();
-
-    println!("Done in main");
+    println!("Done with MultiProgress");
 }


### PR DESCRIPTION
This change moves drawing of MultiProgress from the join() thread to the child ProgressBar updates.  fixes #125, #33 and lay groud work for work on #205

**It is backwards-incompatible.**

It is based on the work of @marienz  in #231 more discussion and detail on that pull request.