### PR TITLE
Fix: Code is actually reachable

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -453,7 +453,7 @@ impl ProgressDrawTarget {
         match self.kind {
             ProgressDrawTargetKind::Term { ref term, .. } => term.size().1 as usize,
             ProgressDrawTargetKind::Remote { ref state, .. } => state.read().unwrap().width(),
-            ProgressDrawTargetKind::Hidden => unreachable!(),
+            ProgressDrawTargetKind::Hidden => 0,
         }
     }
 


### PR DESCRIPTION
This fixes an reachable `unreachable!()` statement.
This might not be the approprite fix, although it resulted in no panic
in the code I used to test it, so it seems appropriate as a first idea
for a proper fix.

---

If you think this is a good first idea, please release it as a patchlevel update (`v0.16.1`)!

Related to #285 (but there might be a better fix)