### PR TITLE
Make unreachable `width` actually unreachable

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -444,7 +444,9 @@ impl ProgressDrawTarget {
         match self.kind {
             ProgressDrawTargetKind::Hidden => true,
             ProgressDrawTargetKind::Term { ref term, .. } => !term.is_term(),
-            _ => false,
+            ProgressDrawTargetKind::Remote { ref state, .. } => {
+                state.read().unwrap().draw_target.is_hidden()
+            }
         }
     }
 


### PR DESCRIPTION
Normally `width` is only called after `is_hidden` returns false but in
the case of a `ProgressDrawTargetKind::Remote` it always returned
false even if the draw target was actually hidden and because of it
drawing did call `width`

Alternative to #286, fixes #285 

cc @matthiasbeyer I'm pretty sure this fixes the problem, but just to be certain could you check?