### PR TITLE
ProgressFolder shouldn't finish progress bars on completion

### DIFF
--- a/src/rayon.rs
+++ b/src/rayon.rs
@@ -180,9 +180,6 @@ impl<T, C: Folder<T>> Folder<T> for ProgressFolder<C> {
     }
 
     fn complete(self) -> C::Result {
-        if !self.progress.is_finished() {
-            self.progress.finish_using_style();
-        }
         self.base.complete()
     }
 


### PR DESCRIPTION
ProgressFolders represent only a part of the whole iterator and
so shouldn't finish progress bars as they don't have knowledge
of the completion of the rest of folders and otherwise could
prematurely finish a progress bar. Progress bar will still finish
when the iterator is dropped.

Fixes #289