### PR TITLE
Add ability to customize template keys

### DIFF
--- a/examples/download.rs
+++ b/examples/download.rs
@@ -11,6 +11,7 @@ fn main() {
     let pb = ProgressBar::new(total_size);
     pb.set_style(ProgressStyle::default_bar()
         .template("{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {bytes}/{total_bytes} ({eta})")
+        .with_key("eta", |state| format!("{:.1}s", state.eta().as_secs_f64()))
         .progress_chars("#>-"));
 
     while downloaded < total_size {

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -187,7 +187,9 @@ impl ProgressBar {
     pub fn set_draw_rate(&self, n: u64) {
         let mut state = self.state.lock().unwrap();
         state.draw_rate = n;
-        state.draw_next = state.pos.saturating_add(state.per_sec() / n);
+        state.draw_next = state
+            .pos
+            .saturating_add((state.per_sec() / n as f64) as u64);
     }
 
     /// Manually ticks the spinner or progress bar
@@ -477,7 +479,7 @@ impl ProgressBar {
     }
 
     /// Returns the current rate of progress
-    pub fn per_sec(&self) -> u64 {
+    pub fn per_sec(&self) -> f64 {
         self.state.lock().unwrap().per_sec()
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -8,10 +8,10 @@ use crate::draw_target::{ProgressDrawState, ProgressDrawTarget};
 use crate::style::{ProgressFinish, ProgressStyle};
 
 /// The state of a progress bar at a moment in time.
-pub(crate) struct ProgressState {
+pub struct ProgressState {
     pub(crate) style: ProgressStyle,
-    pub(crate) pos: u64,
-    pub(crate) len: u64,
+    pub pos: u64,
+    pub len: u64,
     pub(crate) tick: u64,
     pub(crate) started: Instant,
     pub(crate) draw_target: ProgressDrawTarget,
@@ -82,11 +82,6 @@ impl ProgressState {
         pct.max(0.0).min(1.0)
     }
 
-    /// Returns the position of the status bar as `(pos, len)` tuple.
-    pub fn position(&self) -> (u64, u64) {
-        (self.pos, self.len)
-    }
-
     /// Returns the current message of the progress bar.
     pub fn message(&self) -> &str {
         &self.message
@@ -120,12 +115,12 @@ impl ProgressState {
     }
 
     /// The number of steps per second
-    pub fn per_sec(&self) -> u64 {
-        let avg_time = self.est.seconds_per_step();
-        if avg_time == 0.0 {
-            0
+    pub fn per_sec(&self) -> f64 {
+        let per_sec = 1.0 / self.est.seconds_per_step();
+        if per_sec.is_nan() {
+            0.0
         } else {
-            (1.0 / avg_time) as u64
+            per_sec
         }
     }
 
@@ -157,7 +152,7 @@ impl ProgressState {
         }
         if new_pos >= self.draw_next {
             self.draw_next = new_pos.saturating_add(if self.draw_rate != 0 {
-                self.per_sec() / self.draw_rate
+                (self.per_sec() / self.draw_rate as f64) as u64
             } else {
                 self.draw_delta
             });


### PR DESCRIPTION
This PR makes the `pos` and `len` fields of `ProgressState` to have `pub` visibility. I changed the `per_sec` method of `ProgressState` to return an `f64`, and `{per_sec}` in the template now rounds to an integer via the `format!` macro (rather than truncating by default), and is explicitly truncated in other places of the code. With this patch, you can now use `.key(...)` method from `ProgressStyle` to add a custom formatting function and template key. This PR also adds another example to show the usage of this feature.

I also changed the `position` method to just be 2 separate methods for returning the position and length, because the usage beforehand where `position()` was called before matching the template keys and then you would just reuse those for `{pos}` and `{len}` now seems like an anti-pattern with this hash map based approach.  

Also I had to remove `#[derive(Debug)]` for `ProgressStyle` because I was getting errors of "`Debug` impl is not general enough" or something like that, and it didn't seem to be necessary anyway.