### PR TITLE
Adding ProgressIterator::progress_with_style() and taking care of minor typos and clippy lints

### DIFF
--- a/examples/multi-tree-ext.rs
+++ b/examples/multi-tree-ext.rs
@@ -224,7 +224,7 @@ pub fn main() {
                     let pb = mp2.insert(item.index, item.progress_bar.clone());
                     pb.set_prefix("  ".repeat(item.indent));
                     pb.set_message(&item.key);
-                    items.insert(item.index, &item);
+                    items.insert(item.index, item);
                 }
                 Elem::RemoveItem(Index(index)) => {
                     let item = items.remove(*index);

--- a/examples/multi-tree.rs
+++ b/examples/multi-tree.rs
@@ -115,7 +115,7 @@ fn main() {
                     let elem = &ELEMENTS[el_idx];
                     let pb = mp2.insert(elem.index + 1, elem.progress_bar.clone());
                     pb.set_message(format!("{}  {}", "  ".repeat(elem.indent), elem.key));
-                    tree.lock().unwrap().insert(elem.index, &elem);
+                    tree.lock().unwrap().insert(elem.index, elem);
                 }
                 Some(Action::IncProgressBar(el_idx)) => {
                     let elem = &tree.lock().unwrap()[el_idx];

--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -305,7 +305,7 @@ impl MultiProgressState {
         let finished = !self
             .draw_states
             .iter()
-            .any(|ref x| !x.as_ref().map(|s| s.finished).unwrap_or(false));
+            .any(|x| !x.as_ref().map(|s| s.finished).unwrap_or(false));
         self.draw_target.apply_draw_state(ProgressDrawState {
             lines,
             orphan_lines: orphan_lines_count,

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -33,6 +33,16 @@ where
 
     /// Wrap an iterator with a custom progress bar.
     fn progress_with(self, progress: ProgressBar) -> ProgressBarIter<Self>;
+
+    /// Wrap an iterator with a progress bar and style it.
+    fn progress_with_style(self, style: crate::ProgressStyle) -> ProgressBarIter<Self>
+    where 
+        Self: ExactSizeIterator,
+    {
+        let len = u64::try_from(self.len()).unwrap();
+        let bar = ProgressBar::new(len).with_style(style);
+        self.progress_with(bar)
+    }
 }
 
 /// Wraps an iterator to display its progress.
@@ -164,6 +174,7 @@ impl<S, T: Iterator<Item = S>> ProgressIterator for T {
 
 #[cfg(test)]
 mod test {
+    use crate::ProgressStyle;
     use crate::iter::{ProgressBarIter, ProgressIterator};
     use crate::progress_bar::ProgressBar;
 
@@ -179,6 +190,10 @@ mod test {
         wrap({
             let pb = ProgressBar::new(v.len() as u64);
             v.iter().progress_with(pb)
+        });
+        wrap({
+            let style = ProgressStyle::default_bar().template("{wide_bar:.red} {percent}/100%");
+            v.iter().progress_with_style(style)
         });
     }
 }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -36,7 +36,7 @@ where
 
     /// Wrap an iterator with a progress bar and style it.
     fn progress_with_style(self, style: crate::ProgressStyle) -> ProgressBarIter<Self>
-    where 
+    where
         Self: ExactSizeIterator,
     {
         let len = u64::try_from(self.len()).unwrap();
@@ -174,9 +174,9 @@ impl<S, T: Iterator<Item = S>> ProgressIterator for T {
 
 #[cfg(test)]
 mod test {
-    use crate::ProgressStyle;
     use crate::iter::{ProgressBarIter, ProgressIterator};
     use crate::progress_bar::ProgressBar;
+    use crate::ProgressStyle;
 
     #[test]
     fn it_can_wrap_an_iterator() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@
 //! use indicatif::{ProgressBar, ParallelProgressIterator, ProgressStyle};
 //! use rayon::iter::{ParallelIterator, IntoParallelRefIterator};
 //!
-//! // Alternatively, use `ProgressBar::new().with_style()` 
+//! // Alternatively, use `ProgressBar::new().with_style()`
 //! let style = ProgressStyle::default_bar();
 //! let v: Vec<_> = (0..100000).collect();
 //! let v2: Vec<_> = v.par_iter().progress_with_style(style).map(|i| i + 1).collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,13 +107,13 @@
 //!
 //! ```rust,ignore
 //! # extern crate rayon;
-//! use indicatif::{ProgressBar, ParallelProgressIterator};
+//! use indicatif::{ProgressBar, ParallelProgressIterator, ProgressStyle};
 //! use rayon::iter::{ParallelIterator, IntoParallelRefIterator};
 //!
-//! // Use `ProgressBar::with_style` to change the view
-//! let pb = ProgressBar::new();
+//! // Alternatively, use `ProgressBar::new().with_style()` 
+//! let style = ProgressStyle::default_bar();
 //! let v: Vec<_> = (0..100000).collect();
-//! let v2: Vec<_> = v.par_iter().progress_with(pb).map(|i| i + 1).collect();
+//! let v2: Vec<_> = v.par_iter().progress_with_style(style).map(|i| i + 1).collect();
 //! assert_eq!(v2[0], 1);
 //! ```
 //!

--- a/src/rayon.rs
+++ b/src/rayon.rs
@@ -28,6 +28,16 @@ where
         let len = u64::try_from(self.len()).unwrap();
         self.progress_count(len)
     }
+
+    /// Wrap an iterator with a progress bar and style it.
+    fn progress_with_style(self, style: crate::ProgressStyle) -> ProgressBarIter<Self>
+    where
+        Self: IndexedParallelIterator,
+    {
+        let len = u64::try_from(self.len()).unwrap();
+        let bar = ProgressBar::new(len).with_style(style);
+        self.progress_with(bar)
+    }
 }
 
 impl<S: Send, T: ParallelIterator<Item = S>> ParallelProgressIterator for T {
@@ -199,6 +209,7 @@ impl<S: Send, T: ParallelIterator<Item = S>> ParallelIterator for ProgressBarIte
 
 #[cfg(test)]
 mod test {
+    use crate::ProgressStyle;
     use crate::{ParallelProgressIterator, ProgressBar, ProgressBarIter};
     use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
@@ -213,6 +224,11 @@ mod test {
         wrap({
             let pb = ProgressBar::new(v.len() as u64);
             v.par_iter().progress_with(pb)
+        });
+
+        wrap({
+            let style = ProgressStyle::default_bar().template("{wide_bar:.red} {percent}/100%");
+            v.par_iter().progress_with_style(style)
         });
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -239,7 +239,7 @@ impl ProgressState {
         }
 
         let lines = match self.should_render() {
-            true => self.style.format_state(&self),
+            true => self.style.format_state(self),
             false => Vec::new(),
         };
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -119,7 +119,7 @@ impl ProgressStyle {
 
     /// Sets the progress characters `(filled, current, to do)`
     ///
-    /// You can pass more then three for a more detailed display.
+    /// You can pass more than three for a more detailed display.
     /// All passed grapheme clusters need to be of equal width.
     pub fn progress_chars(mut self, s: &str) -> ProgressStyle {
         self.progress_chars = segment(s);


### PR DESCRIPTION
I've added `ProgressIterator::progress_with_style()`, as discussed in https://github.com/mitsuhiko/indicatif/issues/305. Further, I have corrected a small typo and taken care of two clippy warnings. 

Resolves #305 