### PR TITLE
Pass through stream_position in ProgressBarIter

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -134,6 +134,11 @@ impl<S: io::Seek> io::Seek for ProgressBarIter<S> {
             pos
         })
     }
+    // Pass this through to preserve optimizations that the inner I/O object may use here
+    // Also avoid sending a set_position update when the position hasn't changed
+    fn stream_position(&mut self) -> io::Result<u64> {
+        self.it.stream_position()
+    }
 }
 
 impl<W: io::Write> io::Write for ProgressBarIter<W> {


### PR DESCRIPTION
This avoids sending a stream_position update and also preserves optimizations that the underlying object may have made for stream_position.

For example, when wrapping a `BufReader` object, adding this impl allows the use of `.stream_position()` in functions that take a generic `Seek` object without causing the performance drop associated with the default impl of `stream_position` calling `seek(SeekFrom::Current(0))` and throwing away the buffer each time.