### PR TITLE
Add sleep in iterator example to see bars

### DIFF
--- a/examples/iterator.rs
+++ b/examples/iterator.rs
@@ -1,14 +1,19 @@
+use std::thread;
+use std::time::Duration;
+
 use indicatif::{ProgressBar, ProgressIterator, ProgressStyle};
 
 fn main() {
     // Default styling, attempt to use Iterator::size_hint to count input size
     for _ in (0..1000).progress() {
         // ...
+        thread::sleep(Duration::from_millis(5));
     }
 
     // Provide explicit number of elements in iterator
     for _ in (0..1000).progress_count(1000) {
         // ...
+        thread::sleep(Duration::from_millis(5));
     }
 
     // Provide a custom bar style
@@ -18,5 +23,6 @@ fn main() {
     ));
     for _ in (0..1000).progress_with(pb) {
         // ...
+        thread::sleep(Duration::from_millis(5));
     }
 }


### PR DESCRIPTION
I've added the sleep to be able to see the bars when I run the example. They were very quickly done without a `sleep`.