### PR TITLE
Use once_cell instead of lazy_static

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["screenshots/*"]
 
 [dependencies]
 regex = { version = "1.3.1", default-features = false, features = ["std"] }
-lazy_static = "1.0"
+once_cell = "1.8.0"
 number_prefix = "0.4"
 console = { version = "0.15.0", default-features = false, features = ["ansi-parsing"] }
 unicode-segmentation = { version = "1.6.0", optional = true }

--- a/examples/multi-tree-ext.rs
+++ b/examples/multi-tree-ext.rs
@@ -1,6 +1,6 @@
 use console::style;
 use indicatif::{MultiProgress, MultiProgressAlignment, ProgressBar, ProgressStyle};
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use rand::{rngs::ThreadRng, Rng, RngCore};
 use std::fmt::Debug;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -36,61 +36,61 @@ struct Index(usize);
 const PB_LEN: u64 = 32;
 static ELEM_IDX: AtomicUsize = AtomicUsize::new(0);
 
-lazy_static! {
-    static ref ELEMENTS: [Elem; 27] = [
+static ELEMENTS: Lazy<[Elem; 27]> = Lazy::new(|| {
+    [
         Elem::AddItem(Item {
             indent: 9,
             index: 0,
             progress_bar: ProgressBar::new(PB_LEN),
-            key: "dog".to_string()
+            key: "dog".to_string(),
         }),
         Elem::AddItem(Item {
             indent: 0,
             index: 0,
             progress_bar: ProgressBar::new(PB_LEN),
-            key: "temp_1".to_string()
+            key: "temp_1".to_string(),
         }),
         Elem::AddItem(Item {
             indent: 8,
             index: 1,
             progress_bar: ProgressBar::new(PB_LEN),
-            key: "lazy".to_string()
+            key: "lazy".to_string(),
         }),
         Elem::AddItem(Item {
             indent: 0,
             index: 1,
             progress_bar: ProgressBar::new(PB_LEN),
-            key: "temp_2".to_string()
+            key: "temp_2".to_string(),
         }),
         Elem::AddItem(Item {
             indent: 1,
             index: 0,
             progress_bar: ProgressBar::new(PB_LEN),
-            key: "the".to_string()
+            key: "the".to_string(),
         }),
         Elem::AddItem(Item {
             indent: 0,
             index: 0,
             progress_bar: ProgressBar::new(PB_LEN),
-            key: "temp_3".to_string()
+            key: "temp_3".to_string(),
         }),
         Elem::AddItem(Item {
             indent: 7,
             index: 3,
             progress_bar: ProgressBar::new(PB_LEN),
-            key: "a".to_string()
+            key: "a".to_string(),
         }),
         Elem::AddItem(Item {
             indent: 0,
             index: 3,
             progress_bar: ProgressBar::new(PB_LEN),
-            key: "temp_4".to_string()
+            key: "temp_4".to_string(),
         }),
         Elem::AddItem(Item {
             indent: 6,
             index: 2,
             progress_bar: ProgressBar::new(PB_LEN),
-            key: "over".to_string()
+            key: "over".to_string(),
         }),
         Elem::RemoveItem(Index(6)),
         Elem::RemoveItem(Index(4)),
@@ -100,63 +100,63 @@ lazy_static! {
             indent: 0,
             index: 2,
             progress_bar: ProgressBar::new(PB_LEN),
-            key: "temp_5".to_string()
+            key: "temp_5".to_string(),
         }),
         Elem::AddItem(Item {
             indent: 4,
             index: 1,
             progress_bar: ProgressBar::new(PB_LEN),
-            key: "fox".to_string()
+            key: "fox".to_string(),
         }),
         Elem::AddItem(Item {
             indent: 0,
             index: 1,
             progress_bar: ProgressBar::new(PB_LEN),
-            key: "temp_6".to_string()
+            key: "temp_6".to_string(),
         }),
         Elem::AddItem(Item {
             indent: 2,
             index: 1,
             progress_bar: ProgressBar::new(PB_LEN),
-            key: "quick".to_string()
+            key: "quick".to_string(),
         }),
         Elem::AddItem(Item {
             indent: 0,
             index: 1,
             progress_bar: ProgressBar::new(PB_LEN),
-            key: "temp_7".to_string()
+            key: "temp_7".to_string(),
         }),
         Elem::AddItem(Item {
             indent: 5,
             index: 5,
             progress_bar: ProgressBar::new(PB_LEN),
-            key: "jumps".to_string()
+            key: "jumps".to_string(),
         }),
         Elem::AddItem(Item {
             indent: 0,
             index: 5,
             progress_bar: ProgressBar::new(PB_LEN),
-            key: "temp_8".to_string()
+            key: "temp_8".to_string(),
         }),
         Elem::AddItem(Item {
             indent: 3,
             index: 4,
             progress_bar: ProgressBar::new(PB_LEN),
-            key: "brown".to_string()
+            key: "brown".to_string(),
         }),
         Elem::AddItem(Item {
             indent: 0,
             index: 3,
             progress_bar: ProgressBar::new(PB_LEN),
-            key: "temp_9".to_string()
+            key: "temp_9".to_string(),
         }),
         Elem::RemoveItem(Index(10)),
         Elem::RemoveItem(Index(7)),
         Elem::RemoveItem(Index(4)),
         Elem::RemoveItem(Index(3)),
         Elem::RemoveItem(Index(1)),
-    ];
-}
+    ]
+});
 
 #[derive(Debug, StructOpt)]
 #[structopt(setting = structopt::clap::AppSettings::ColoredHelp)]

--- a/examples/multi-tree.rs
+++ b/examples/multi-tree.rs
@@ -1,5 +1,5 @@
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use rand::{rngs::ThreadRng, Rng, RngCore};
 use std::fmt::Debug;
 use std::sync::{Arc, Mutex};
@@ -20,64 +20,64 @@ struct Elem {
     progress_bar: ProgressBar,
 }
 
-lazy_static! {
-    static ref ELEMENTS: [Elem; 9] = [
+static ELEMENTS: Lazy<[Elem; 9]> = Lazy::new(|| {
+    [
         Elem {
             indent: 1,
             index: 0,
             progress_bar: ProgressBar::new(32),
-            key: "jumps".to_string()
+            key: "jumps".to_string(),
         },
         Elem {
             indent: 2,
             index: 1,
             progress_bar: ProgressBar::new(32),
-            key: "lazy".to_string()
+            key: "lazy".to_string(),
         },
         Elem {
             indent: 0,
             index: 0,
             progress_bar: ProgressBar::new(32),
-            key: "the".to_string()
+            key: "the".to_string(),
         },
         Elem {
             indent: 3,
             index: 3,
             progress_bar: ProgressBar::new(32),
-            key: "dog".to_string()
+            key: "dog".to_string(),
         },
         Elem {
             indent: 2,
             index: 2,
             progress_bar: ProgressBar::new(32),
-            key: "over".to_string()
+            key: "over".to_string(),
         },
         Elem {
             indent: 2,
             index: 1,
             progress_bar: ProgressBar::new(32),
-            key: "brown".to_string()
+            key: "brown".to_string(),
         },
         Elem {
             indent: 1,
             index: 1,
             progress_bar: ProgressBar::new(32),
-            key: "quick".to_string()
+            key: "quick".to_string(),
         },
         Elem {
             indent: 3,
             index: 5,
             progress_bar: ProgressBar::new(32),
-            key: "a".to_string()
+            key: "a".to_string(),
         },
         Elem {
             indent: 3,
             index: 3,
             progress_bar: ProgressBar::new(32),
-            key: "fox".to_string()
+            key: "fox".to_string(),
         },
-    ];
-}
+    ]
+});
 
 /// The example implements the tree-like collection of progress bars, where elements are
 /// added on the fly and progress bars get incremented until all elements is added and

--- a/src/style.rs
+++ b/src/style.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 
 use console::{measure_text_width, Style};
+use once_cell::sync::Lazy;
 use regex::{Captures, Regex};
 #[cfg(feature = "improved_unicode")]
 use unicode_segmentation::UnicodeSegmentation;
@@ -321,9 +322,9 @@ impl ProgressStyle {
 }
 
 fn expand_template<F: FnMut(&TemplateVar<'_>) -> String>(s: &str, mut f: F) -> Cow<'_, str> {
-    lazy_static::lazy_static! {
-        static ref VAR_RE: Regex = Regex::new(r"(\}\})|\{(\{|[^{}}]+\})").unwrap();
-        static ref KEY_RE: Regex = Regex::new(
+    static VAR_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(\}\})|\{(\{|[^{}}]+\})").unwrap());
+    static KEY_RE: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
             r"(?x)
                 ([^:]+)
                 (?:
@@ -334,10 +335,10 @@ fn expand_template<F: FnMut(&TemplateVar<'_>) -> String>(s: &str, mut f: F) -> C
                     (?:\.([0-9a-z_]+(?:\.[0-9a-z_]+)*))?
                     (?:/([a-z_]+(?:\.[a-z_]+)*))?
                 )?
-            "
+            ",
         )
-        .unwrap();
-    }
+        .unwrap()
+    });
     VAR_RE.replace_all(s, |caps: &Captures<'_>| {
         if caps.get(1).is_some() {
             return "}".into();


### PR DESCRIPTION
The motivation is that console already uses once_cell, so this should in theory decrease the total number of dependencies.

Note: The formatting has changed, do you happen to use some rustfmt flags? if so it would be better if you have a `.rustfmt.toml` file.