### PR TITLE
ProgressBar: Add with_elapsed for overridding elapsed time

### DIFF
--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -77,6 +77,12 @@ impl ProgressBar {
         self
     }
 
+    /// A convenience builder-like function for a progress bar with a given elapsed time
+    pub fn with_elapsed(self, elapsed: Duration) -> ProgressBar {
+        self.state.lock().unwrap().started = Instant::now() - elapsed;
+        self
+    }
+
     /// Creates a new spinner
     ///
     /// This spinner by default draws directly to stderr. This adds the default spinner style to it.


### PR DESCRIPTION
This PR adds `ProgressBar::with_elapsed()` which provides a way to override the elapsed time of a progress bar.

This is useful for scenarios where you dynamically create additional ProgressBars for "sub-tasks" and want to preserve the elapsed time in the output. Since ProgressBar exposes the elapsed time as a Duration, `with_elapsed` is more ergonomic than `with_start_time`.