### PR TITLE
[Request for comment; not ready for merge]: add insert_after / insert_before to MultiProgress

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ regex = { version = "1.3.1", default-features = false, features = ["std"] }
 once_cell = "1.8.0"
 number_prefix = "0.4"
 console = { version = "0.15.0", default-features = false, features = ["ansi-parsing"] }
+generational_token_list = "0.1.1"
 unicode-segmentation = { version = "1.6.0", optional = true }
 unicode-width = { version = "0.1.7", optional = true }
 rayon = { version = "1.0", optional = true }
@@ -25,6 +26,7 @@ tokio = { version = "1.0", optional = true, features = ["fs", "io-util"] }
 rand = "0.8"
 structopt = "0.3"
 tokio = { version = "1.0", features = ["time", "rt"] }
+pretty_assertions = "1.0.0"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ regex = { version = "1.3.1", default-features = false, features = ["std"] }
 once_cell = "1.8.0"
 number_prefix = "0.4"
 console = { version = "0.15.0", default-features = false, features = ["ansi-parsing"] }
-generational_token_list = "0.1.1"
+generational_token_list = "0.1.2"
 unicode-segmentation = { version = "1.6.0", optional = true }
 unicode-width = { version = "0.1.7", optional = true }
 rayon = { version = "1.0", optional = true }

--- a/examples/multi-tree-ext.rs
+++ b/examples/multi-tree-ext.rs
@@ -221,9 +221,9 @@ pub fn main() {
             }
             Action::ModifyTree(elem_idx) => match &ELEMENTS[elem_idx] {
                 Elem::AddItem(item) => {
-                    let pb = mp2.insert(item.index, item.progress_bar.clone());
-                    pb.set_prefix("  ".repeat(item.indent));
-                    pb.set_message(&item.key);
+                    // let pb = mp2.insert(item.index, item.progress_bar.clone());
+                    // pb.set_prefix("  ".repeat(item.indent));
+                    // pb.set_message(&item.key);
                     items.insert(item.index, item);
                 }
                 Elem::RemoveItem(Index(index)) => {

--- a/examples/multi-tree.rs
+++ b/examples/multi-tree.rs
@@ -113,8 +113,8 @@ fn main() {
                 }
                 Some(Action::AddProgressBar(el_idx)) => {
                     let elem = &ELEMENTS[el_idx];
-                    let pb = mp2.insert(elem.index + 1, elem.progress_bar.clone());
-                    pb.set_message(format!("{}  {}", "  ".repeat(elem.indent), elem.key));
+                    //let pb = mp2.insert(elem.index + 1, elem.progress_bar.clone());
+                    //pb.set_message(format!("{}  {}", "  ".repeat(elem.indent), elem.key));
                     tree.lock().unwrap().insert(elem.index, elem);
                 }
                 Some(Action::IncProgressBar(el_idx)) => {


### PR DESCRIPTION
This greatly simplifies the code. It also clarifies the API very nicely:
the old MultiProgress::insert method is not practically useful since the
indices do not necessarilly correspond to visual order, except for
specific usage patterns.

The ability to insert after/before particular progress bars is much more
useful.