### PR TITLE
Implement ProgressBar::suspend

### DIFF
--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -138,7 +138,7 @@ impl ProgressBar {
                 }
                 ms = state.steady_tick;
 
-                state.draw().ok();
+                state.draw(false).ok();
             } else {
                 break;
             }
@@ -248,7 +248,6 @@ impl ProgressBar {
         let draw_state = ProgressDrawState {
             lines,
             orphan_lines,
-            finished: state.is_finished(),
             force_draw: true,
             move_cursor: false,
             alignment: Default::default(),
@@ -728,7 +727,6 @@ impl MultiProgress {
         state.draw_target.apply_draw_state(ProgressDrawState {
             lines: vec![],
             orphan_lines: 0,
-            finished: true,
             force_draw: true,
             move_cursor,
             alignment,

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -766,12 +766,19 @@ impl MultiProgress {
 /// A weak reference to a `ProgressBar`.
 ///
 /// Useful for creating custom steady tick implementations
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct WeakProgressBar {
     state: Weak<Mutex<ProgressState>>,
 }
 
 impl WeakProgressBar {
+    /// Create a new `WeakProgressBar` that returns `None` when [`upgrade`] is called.
+    ///
+    /// [`upgrade`]: WeakProgressBar::upgrade
+    pub fn new(&self) -> WeakProgressBar {
+        Default::default()
+    }
+
     /// Attempts to upgrade the Weak pointer to a [`ProgressBar`], delaying dropping of the inner
     /// value if successful. Returns `None` if the inner value has since been dropped.
     ///

--- a/src/state.rs
+++ b/src/state.rs
@@ -124,7 +124,7 @@ impl ProgressState {
     /// progress bar if the state has changed.
     pub fn update_and_draw<F: FnOnce(&mut ProgressState)>(&mut self, f: F) {
         if self.update(f) {
-            self.draw().ok();
+            self.draw(false).ok();
         }
     }
 
@@ -135,7 +135,7 @@ impl ProgressState {
             state.draw_next = state.pos;
             f(state);
         });
-        self.draw().ok();
+        self.draw(true).ok();
     }
 
     /// Call the provided `FnOnce` to update the state. If a draw should be run, returns `true`.
@@ -228,7 +228,7 @@ impl ProgressState {
         }
     }
 
-    pub(crate) fn draw(&mut self) -> io::Result<()> {
+    pub(crate) fn draw(&mut self, force_draw: bool) -> io::Result<()> {
         // we can bail early if the draw target is hidden.
         if self.draw_target.is_hidden() {
             return Ok(());
@@ -239,7 +239,9 @@ impl ProgressState {
             false => Vec::new(),
         };
 
-        let draw_state = ProgressDrawState::new(lines, self.is_finished());
+        // `|| self.is_finished()` should not be needed here, but we used to always for draw for
+        // finished progress bar, so it's kept as to not cause compatibility issues in weird cases.
+        let draw_state = ProgressDrawState::new(lines, force_draw || self.is_finished());
         self.draw_target.apply_draw_state(draw_state)
     }
 }


### PR DESCRIPTION
This function hides the progress bar temporarily, execute `f`, then redraws the progress bar, which is useful for external code that writes to the standard output.

The idea is originally raised in #92.

It is planned to eventually create a global function like `ProgressBar::instance` that allows calling `suspend` from e.g. a log handler, but this currently doesn't generalize to `MultiProgressBar` which could be an obstacle.